### PR TITLE
Increase masking flexibility for normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ The paths suffix must be `.nii`, `.nii.gz` or `.nrrd`.
 import torchio
 
 subject_a = [
-    Image('t1', '~/Dropbox/MRI/t1.nii.gz', torchio.INTENSITY),
+    Image('t1', '~/Dropbox/MRI/t1.nrrd', torchio.INTENSITY),
     Image('label', '~/Dropbox/MRI/t1_seg.nii.gz', torchio.LABEL),
 ]
 subject_b = [
     Image('t1', '/tmp/colin27_t1_tal_lin.nii.gz', torchio.INTENSITY),
+    Image('t2', '/tmp/colin27_t2_tal_lin.nii', torchio.INTENSITY),
     Image('label', '/tmp/colin27_seg1.nii.gz', torchio.LABEL),
 ]
 subjects_list = [subject_a, subject_b]

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ A transform can be quickly applied to an image file using the command-line
 tool `torchio-transform`:
 
 ```shell
-$ torchio-transform input.nii.gz RandomMotion output.nii.gz
+$ torchio-transform input.nii.gz RandomMotion output.nii.gz --kwargs
+"proportion_to_augment=1,num_transforms=4"
 ```
 
 #### Intensity

--- a/torchio/cli.py
+++ b/torchio/cli.py
@@ -5,34 +5,63 @@ import click
 
 @click.command()
 @click.argument('input-path', type=click.Path(exists=True))
-@click.argument('transform', type=str)
+@click.argument('transform-name', type=str)
 @click.argument('output-path', type=click.Path())
-@click.option('--kwargs', '-k', type=str, show_default=True)
-@click.option('--seed', '-s', type=int, show_default=True)
+@click.option('--kwargs', '-k', type=str, help='String of kwargs, e.g. "proportion_to_augment=1,num_transforms=3"')
+@click.option('--seed', '-s', type=int, help='Seed for PyTorch random number generator')
 @click.option('--verbose/--no-verbose', '-v', default=False, show_default=True)
-def apply_transform(input_path, transform, output_path, kwargs, seed, verbose):
-    """Apply transform to an image."""
+def apply_transform(input_path, transform_name, output_path, kwargs, seed, verbose):
+    """Apply transform to an image.
+
+    \b
+    Example:
+    $ torchio-transform input.nrrd RandomMotion output.nii --kwargs "proportion_to_augment=1,num_transforms=3"
+    """
     import torchio.transforms as transforms
     from torchio.utils import apply_transform_to_file
     from torchio.transforms.augmentation import RandomTransform
-    if kwargs is not None:  # TODO: implement this
-        raise NotImplementedError('Passing kwargs not implemented yet')
-    kwargs = {}
+
     try:
-        transform_class = getattr(transforms, transform)
+        transform_class = getattr(transforms, transform_name)
     except AttributeError:
-        raise AttributeError(f'"{transform}" class not found in torchio')
+        raise AttributeError(f'"{transform_name}" class not found in torchio')
+
+    params_dict = {}
+    if kwargs is not None:
+        for substring in kwargs.split():
+            key, value_string = substring.split('=')
+            value_type = guess_type(value_string)
+            try:
+                value = value_type(value_string)
+            except TypeError:
+                value = None
+            params_dict[key] = value
+
     debug_kwargs = dict(verbose=verbose)
     if isinstance(transform_class, RandomTransform):
         debug_kwargs['seed'] = seed
-    kwargs.update(debug_kwargs)
-    transform = transform_class(**kwargs)
+    params_dict.update(debug_kwargs)
+    transform = transform_class(**params_dict)
     apply_transform_to_file(
         input_path,
         transform,
         output_path,
     )
     return 0
+
+
+def guess_type(variable):
+    """
+    Adapted from
+    https://www.reddit.com/r/learnpython/comments/4599hl/module_to_guess_type_from_a_string/czw3f5s
+    """
+    import ast
+    try:
+        value = ast.literal_eval(variable)
+    except ValueError:
+        return str
+    else:
+        return type(value)
 
 
 if __name__ == "__main__":

--- a/torchio/transforms/__init__.py
+++ b/torchio/transforms/__init__.py
@@ -1,4 +1,5 @@
 from .transform import Transform
+from .normalization import NormalizationTransform
 
 # Augmentation
 from .augmentation.spatial import RandomFlip

--- a/torchio/transforms/normalization/__init__.py
+++ b/torchio/transforms/normalization/__init__.py
@@ -1,3 +1,4 @@
+from .normalization_transform import NormalizationTransform
 from .rescale import Rescale
 from .z_normalization import ZNormalization
 from .histogram_standardization import HistogramStandardization

--- a/torchio/transforms/normalization/normalization_transform.py
+++ b/torchio/transforms/normalization/normalization_transform.py
@@ -1,0 +1,45 @@
+import torch
+from .. import Transform
+from ...torchio import INTENSITY
+from ...utils import is_image_dict
+
+
+class NormalizationTransform(Transform):
+    def __init__(self, masking_method=None, verbose=False):
+        super().__init__(verbose=verbose)
+        self.masking_method = masking_method
+        if self.masking_method is None:
+            self.masking_method = self.ones
+        if isinstance(self.masking_method, str):
+            self.mask_name = self.masking_method
+        else:
+            self.mask_name = None
+
+    def get_mask(self, sample, data):
+        if self.mask_name is None:
+            return self.masking_method(data)
+        else:
+            return sample[self.mask_name]['data'].bool()
+
+    def apply_transform(self, sample):
+        for image_name, image_dict in sample.items():
+            if not is_image_dict(image_dict):
+                continue
+            if not image_dict['type'] == INTENSITY:
+                continue
+            mask = self.get_mask(sample, image_dict['data'])
+            self.apply_normalization(sample, image_name, mask)
+        return sample
+
+    def apply_normalization(self, sample, image_name, mask):
+        """There must be a nicer way of doing this"""
+        raise NotImplementedError
+
+    @staticmethod
+    def ones(data):
+        return torch.ones_like(data, dtype=torch.bool)
+
+    @staticmethod
+    def mean(data):
+        mask = data > data.mean()
+        return mask

--- a/torchio/transforms/normalization/normalization_transform.py
+++ b/torchio/transforms/normalization/normalization_transform.py
@@ -6,14 +6,21 @@ from ...utils import is_image_dict
 
 class NormalizationTransform(Transform):
     def __init__(self, masking_method=None, verbose=False):
+        """
+        masking_method is used to choose the values used for normalization.
+        It can be:
+         - A string: the mask will be retrieved from the sample
+         - A function: the mask will be computed using the function
+         - None: all values are used
+        """
         super().__init__(verbose=verbose)
-        self.masking_method = masking_method
-        if self.masking_method is None:
+        self.mask_name = None
+        if masking_method is None:
             self.masking_method = self.ones
-        if isinstance(self.masking_method, str):
+        elif callable(masking_method):
+            self.masking_method = masking_method
+        elif isinstance(self.masking_method, str):
             self.mask_name = self.masking_method
-        else:
-            self.mask_name = None
 
     def get_mask(self, sample, data):
         if self.mask_name is None:

--- a/torchio/transforms/normalization/rescale.py
+++ b/torchio/transforms/normalization/rescale.py
@@ -1,8 +1,5 @@
 import torch
 import numpy as np
-from ...torchio import INTENSITY
-from ...utils import is_image_dict
-from .. import Transform
 from .normalization_transform import NormalizationTransform
 
 

--- a/torchio/transforms/normalization/rescale.py
+++ b/torchio/transforms/normalization/rescale.py
@@ -3,36 +3,38 @@ import numpy as np
 from ...torchio import INTENSITY
 from ...utils import is_image_dict
 from .. import Transform
+from .normalization_transform import NormalizationTransform
 
 
-class Rescale(Transform):
+class Rescale(NormalizationTransform):
     def __init__(
             self,
             out_min_max=(-1, 1),
             percentiles=(1, 99),
+            masking_method=None,
             verbose=False,
             ):
-        super().__init__(verbose=verbose)
+        super().__init__(masking_method=masking_method, verbose=verbose)
         self.out_min, self.out_max = out_min_max
         self.percentiles = percentiles
 
-    def apply_transform(self, sample):
+    def apply_normalization(self, sample, image_name, mask):
         """
         This could probably be written in two or three lines
         """
-        for image_dict in sample.values():
-            if not is_image_dict(image_dict):
-                continue
-            if image_dict['type'] != INTENSITY:
-                continue
-            array = image_dict['data'].numpy()
-            pa, pb = self.percentiles
-            cutoff = np.percentile(array, (pa, pb))
-            np.clip(array, *cutoff, out=array)
-            array -= array.min()  # [0, max]
-            array /= array.max()  # [0, 1]
-            out_range = self.out_max - self.out_min
-            array *= out_range  # [0, out_range]
-            array -= self.out_min  # [out_min, out_max]
-            image_dict['data'] = torch.from_numpy(array)
-            return sample
+        image_dict = sample[image_name]
+        image_dict['data'] = self.rescale(image_dict['data'], mask)
+
+    def rescale(self, data, mask):
+        array = data.numpy()
+        mask = mask.numpy()
+        values = array[mask]
+        pa, pb = self.percentiles
+        cutoff = np.percentile(values, (pa, pb))
+        np.clip(array, *cutoff, out=array)
+        array -= array.min()  # [0, max]
+        array /= array.max()  # [0, 1]
+        out_range = self.out_max - self.out_min
+        array *= out_range  # [0, out_range]
+        array -= self.out_min  # [out_min, out_max]
+        return torch.from_numpy(array)

--- a/torchio/transforms/normalization/z_normalization.py
+++ b/torchio/transforms/normalization/z_normalization.py
@@ -1,42 +1,24 @@
-import torch
-from ...torchio import INTENSITY
-from ...utils import is_image_dict
-from .. import Transform
+from .normalization_transform import NormalizationTransform
 
 
-class ZNormalization(Transform):
+class ZNormalization(NormalizationTransform):
     """
     Subtract mean and divide by standard deviation
     """
-    def __init__(self, use_mean_threshold=True, verbose=False):
-        super().__init__(verbose=verbose)
-        self.use_mean_threshold = use_mean_threshold
+    def __init__(self, masking_method=None, verbose=False):
+        super().__init__(masking_method=masking_method, verbose=verbose)
 
-    def apply_transform(self, sample):
-        masking_function = mean_plus if self.use_mean_threshold else None
-        for image_dict in sample.values():
-            if not is_image_dict(image_dict):
-                continue
-            if image_dict['type'] != INTENSITY:
-                continue
-            image_dict['data'] = znorm(
-                image_dict['data'],
-                masking_function=masking_function,
-            )
-        return sample
+    def apply_normalization(self, sample, image_name, mask):
+        image_dict = sample[image_name]
+        image_dict['data'] = self.znorm(
+            image_dict['data'],
+            mask,
+        )
 
-
-def znorm(data, masking_function):
-    if masking_function is None:
-        mask_data = torch.ones_like(data, dtype=torch.bool)
-    else:
-        mask_data = masking_function(data)
-    values = data[mask_data]
-    mean, std = values.mean(), values.std()
-    data = data - mean
-    data = data / std
-    return data
-
-
-def mean_plus(data):
-    return data > data.mean()
+    @staticmethod
+    def znorm(data, mask):
+        values = data[mask]
+        mean, std = values.mean(), values.std()
+        data = data - mean
+        data = data / std
+        return data


### PR DESCRIPTION
All normalization classes now take a kwarg names `masking_method` that can be:
1. `None`: mask is all ones
2. A string: the sample is queried for the corresponding image name
3. A Python callable such as `torchio.transforms.NormalizationTransform.mean`

Resolves #38.