### PR TITLE
Add kwargs to Image and Subject

### DIFF
--- a/tests/data/test_images_dataset.py
+++ b/tests/data/test_images_dataset.py
@@ -32,11 +32,11 @@ class TestImagesDataset(TorchioTestCase):
             self.iterate_dataset([0])
 
     def test_wrong_subject_type_dict(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.iterate_dataset([{}])
 
     def test_wrong_index(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             self.dataset[:3]
 
     def test_save_sample(self):

--- a/tests/transforms/augmentation/test_random_elastic_deformation.py
+++ b/tests/transforms/augmentation/test_random_elastic_deformation.py
@@ -41,10 +41,6 @@ class TestRandomElasticDeformation(TorchioTestCase):
         with self.assertRaises(TypeError):
             RandomElasticDeformation(image_interpolation='linear')
 
-    def test_deprecation(self):
-        with self.assertWarns(DeprecationWarning):
-            RandomElasticDeformation(deformation_std=15)
-
     def test_num_control_points_noint(self):
         with self.assertRaises(ValueError):
             RandomElasticDeformation(num_control_points=2.5)

--- a/torchio/data/images.py
+++ b/torchio/data/images.py
@@ -33,11 +33,15 @@ class Image:
             :attr:`torchio.LABEL`. This will be used by the transforms to
             decide whether to apply an operation, or which interpolation to use
             when resampling.
+        **kwargs: Items that will be added to image dictionary within the
+            subject sample.
     """
-    def __init__(self, name: str, path: TypePath, type_: str):
+
+    def __init__(self, name: str, path: TypePath, type_: str, **kwargs):
         self.name = name
         self.path = self._parse_path(path)
         self.type = type_
+        self.kwargs = kwargs
 
     def _parse_path(self, path: TypePath) -> Path:
         try:
@@ -80,12 +84,13 @@ class Subject(list):
 
     Args:
         *images: Instances of :py:class:`~torchio.data.images.Image`.
-        name: Subject ID
+        **kwargs: Items that will be added to the subject sample.
     """
-    def __init__(self, *images: Image, name: str = ''):
+
+    def __init__(self, *images: Image, **kwargs):
         self._parse_images(images)
         super().__init__(images)
-        self.name = name
+        self.kwargs = kwargs
 
     def __repr__(self):
         return f'{__class__.__name__}("{self.name}", {len(self)} images)'
@@ -172,6 +177,7 @@ class ImagesDataset(Dataset):
     .. _affine matrix: https://nipy.org/nibabel/coordinate_systems.html
 
     """
+
     def __init__(
             self,
             subjects: Sequence[Subject],
@@ -192,7 +198,7 @@ class ImagesDataset(Dataset):
 
     def __getitem__(self, index: int) -> dict:
         if not isinstance(index, int):
-            raise TypeError(f'Index "{index}" must be int, not {type(index)}')
+            raise ValueError(f'Index "{index}" must be int, not {type(index)}')
         subject = self.subjects[index]
         sample = self.get_sample_dict_from_subject(subject)
 
@@ -207,11 +213,12 @@ class ImagesDataset(Dataset):
         Args:
             subject: Instance of :py:class:`~torchio.data.images.Subject`.
         """
-        sample = {
+        subject_sample = {
             image.name: self.get_image_dict_from_image(image)
             for image in subject
         }
-        return sample
+        subject_sample.update(subject.kwargs)
+        return subject_sample
 
     def get_image_dict_from_image(self, image: Image):
         """Create a dictionary with image information.
@@ -238,6 +245,7 @@ class ImagesDataset(Dataset):
             PATH: str(image.path),
             STEM: get_stem(image.path),
         }
+        image_dict.update(image.kwargs)
         return image_dict
 
     def set_transform(self, transform: Optional[Callable]) -> None:
@@ -264,8 +272,13 @@ class ImagesDataset(Dataset):
             raise ValueError('Subjects list is empty')
 
         # Check each element
-        for subject_list in subjects_list:
-            Subject(*subject_list)
+        for subject in subjects_list:
+            if not isinstance(subject, Subject):
+                message = (
+                    'Subjects list must contain instances of torchio.Subject,'
+                    f' not "{type(subject)}"'
+                )
+                raise TypeError(message)
 
     @classmethod
     def save_sample(

--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -3,7 +3,7 @@ import shutil
 import pprint
 import tempfile
 from pathlib import Path
-from typing import Union, Iterable, Tuple, Any, Optional
+from typing import Union, Iterable, Tuple, Any, Optional, List
 import torch
 import numpy as np
 import nibabel as nib
@@ -65,7 +65,7 @@ def create_dummy_dataset(
         force: bool = False,
         verbose: bool = False,
         ):
-    from .data import Image
+    from .data import Image, Subject
     output_dir = tempfile.gettempdir() if directory is None else directory
     output_dir = Path(output_dir)
     images_dir = output_dir / 'dummy_images'
@@ -75,16 +75,16 @@ def create_dummy_dataset(
         shutil.rmtree(images_dir)
         shutil.rmtree(labels_dir)
 
-    subjects = []
+    subjects: List[Subject] = []
     if images_dir.is_dir():
         for i in trange(num_images):
             image_path = images_dir / f'image_{i}{suffix}'
             label_path = labels_dir / f'label_{i}{suffix}'
-            subject_images = [
+            subject = Subject(
                 Image('one_modality', image_path, INTENSITY),
                 Image('segmentation', label_path, LABEL),
-            ]
-            subjects.append(subject_images)
+            )
+            subjects.append(subject)
     else:
         images_dir.mkdir(exist_ok=True, parents=True)
         labels_dir.mkdir(exist_ok=True, parents=True)
@@ -110,11 +110,11 @@ def create_dummy_dataset(
             nii = nib.Nifti1Image(label.astype(np.uint8), affine)
             nii.to_filename(str(label_path))
 
-            subject_images = [
+            subject = Subject(
                 Image('one_modality', image_path, INTENSITY),
                 Image('segmentation', label_path, LABEL),
-            ]
-            subjects.append(subject_images)
+            )
+            subjects.append(subject)
     return subjects
 
 


### PR DESCRIPTION
This commit allows the user to easily add values to samples generated by
ImagesDataset and to the image dictionaries in the samples.

This is especially useful for regression tasks of a single value, which
can be added to the subject as `Subject(image1, image2, label=1)` or
the image as `Image(name, path, type_, label=1)`.

Resolves #112.

Thanks @nwschurink for bringing this up.