### PR TITLE
CropOrPad only works for even values

### DIFF
--- a/tests/transforms/preprocessing/test_crop_pad.py
+++ b/tests/transforms/preprocessing/test_crop_pad.py
@@ -105,6 +105,13 @@ class TestCropOrPad(TorchioTestCase):
         mask *= 0
         mask [0, 4:6, 5:8, 3:7] = 1
         transformed = transform(self.sample)
+        shapes = []
+        for key in transformed:
+            result_shape = transformed[key][DATA].shape[1:]
+            shapes.append(result_shape)
+        set_shapes = set(shapes)
+        message = f'Images have different shapes: {set_shapes}'
+        assert len(set_shapes) == 1, message
         for key in transformed:
             result_shape = transformed[key][DATA].shape[1:]
             self.assertEqual(target_shape, result_shape,
@@ -118,6 +125,13 @@ class TestCropOrPad(TorchioTestCase):
         mask *= 0
         mask [0, 4:6, 5:8, 3:7] = 1
         transformed = transform(self.sample)
+        shapes = []
+        for key in transformed:
+            result_shape = transformed[key][DATA].shape[1:]
+            shapes.append(result_shape)
+        set_shapes = set(shapes)
+        message = f'Images have different shapes: {set_shapes}'
+        assert len(set_shapes) == 1, message
         for key in transformed:
             result_shape = transformed[key][DATA].shape[1:]
             self.assertEqual(target_shape, result_shape,

--- a/torchio/transforms/preprocessing/spatial/crop_or_pad.py
+++ b/torchio/transforms/preprocessing/spatial/crop_or_pad.py
@@ -191,7 +191,7 @@ class CropOrPad(BoundsTransform):
             return self._compute_center_crop_or_pad(sample=sample)
 
         # Original sample shape (from mask shape)
-        sample_shape = mask.shape[1:]  # remove channels dimension
+        sample_shape = self._get_sample_shape(sample)  # remove channels dimension
         # Calculate bounding box of the mask center
         bb_min, bb_max = self._bbox_mask(mask[0])
         # Coordinates of the mask center
@@ -207,10 +207,10 @@ class CropOrPad(BoundsTransform):
             begin = center_dim - (self.bounds_parameters[2 * dim] / 2)
             end = center_dim + (self.bounds_parameters[2 * dim + 1] / 2)
             # Check if dimension needs padding (before or after)
-            begin_pad = round(abs(min(begin, 0)))
+            begin_pad = round_up(abs(min(begin, 0)))
             end_pad = round(max(end - sample_shape[dim], 0))
             # Check if cropping is needed
-            begin_crop = round(max(begin, 0))
+            begin_crop = round_up(max(begin, 0))
             end_crop = abs(round(min(end - sample_shape[dim], 0)))
             # Add padding values of the dim to the list
             padding.append(begin_pad)

--- a/torchio/transforms/preprocessing/spatial/crop_or_pad.py
+++ b/torchio/transforms/preprocessing/spatial/crop_or_pad.py
@@ -222,7 +222,7 @@ class CropOrPad(BoundsTransform):
         padding = np.asarray(padding, dtype=int)
         cropping = np.asarray(cropping, dtype=int)
         padding_params = tuple(padding.tolist()) if padding.any() else None
-        cropping_params = tuple(cropping.tolist()) if padding.any() else None
+        cropping_params = tuple(cropping.tolist()) if cropping.any() else None
         return padding_params, cropping_params
 
     def apply_transform(self, sample: dict) -> dict:


### PR DESCRIPTION
@GReguig @romainVala tests show that values are properly padded/cropped only for odd values:
`AssertionError: (9, 18, 30) != torch.Size([10, 18, 30]) : Wrong shape for image: t1`
`AssertionError: (11, 22, 30) != torch.Size([10, 22, 30]) : Wrong shape for image: t1`