### PR TITLE
Resample with coregistration (Issue #131)

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -16,3 +16,7 @@ class TestImage(TorchioTestCase):
     def test_wrong_path_type(self):
         with self.assertRaises(TypeError):
             Image(5, INTENSITY)
+
+    def test_bad_key(self):
+        with self.assertRaises(ValueError):
+            Image(5, INTENSITY, affine=1)

--- a/tests/transforms/preprocessing/test_resample.py
+++ b/tests/transforms/preprocessing/test_resample.py
@@ -28,18 +28,23 @@ class TestResample(TorchioTestCase):
                 ref_image_dict[DATA].shape, image_dict[DATA].shape)
             assert_array_equal(ref_image_dict[AFFINE], image_dict[AFFINE])
 
-    def test_coregistration(self):
+    def test_affine(self):
         spacing = 1
-        coregistration_name = 'coregistration'
-        transform = Resample(spacing, coregistration=coregistration_name)
+        affine_name = 'pre_affine'
+        transform = Resample(spacing, pre_affine_name=affine_name)
         transformed = transform(self.sample)
         for image_dict in transformed.values():
-            if coregistration_name in image_dict.keys():
+            if affine_name in image_dict.keys():
                 new_affine = np.eye(4)
                 new_affine[0, 3] = 10
                 assert_array_equal(image_dict[AFFINE], new_affine)
             else:
                 assert_array_equal(image_dict[AFFINE], np.eye(4))
+
+    def test_missing_affine(self):
+        transform = Resample(1, pre_affine_name='missing')
+        with self.assertRaises(ValueError):
+            transform(self.sample)
 
     def test_wrong_spacing_length(self):
         with self.assertRaises(ValueError):
@@ -55,10 +60,5 @@ class TestResample(TorchioTestCase):
 
     def test_missing_reference(self):
         transform = Resample('missing')
-        with self.assertRaises(ValueError):
-            transform(self.sample)
-
-    def test_missing_coregistration(self):
-        transform = Resample(1, coregistration='missing')
         with self.assertRaises(ValueError):
             transform(self.sample)

--- a/tests/transforms/preprocessing/test_resample.py
+++ b/tests/transforms/preprocessing/test_resample.py
@@ -57,3 +57,8 @@ class TestResample(TorchioTestCase):
         transform = Resample('missing')
         with self.assertRaises(ValueError):
             transform(self.sample)
+
+    def test_missing_coregistration(self):
+        transform = Resample(1, coregistration='missing')
+        with self.assertRaises(ValueError):
+            transform(self.sample)

--- a/tests/transforms/preprocessing/test_resample.py
+++ b/tests/transforms/preprocessing/test_resample.py
@@ -1,3 +1,4 @@
+import numpy as np
 from numpy.testing import assert_array_equal
 from torchio import DATA, AFFINE
 from torchio.transforms import Resample
@@ -26,6 +27,19 @@ class TestResample(TorchioTestCase):
             self.assertEqual(
                 ref_image_dict[DATA].shape, image_dict[DATA].shape)
             assert_array_equal(ref_image_dict[AFFINE], image_dict[AFFINE])
+
+    def test_coregistration(self):
+        spacing = 1
+        coregistration_name = 'coregistration'
+        transform = Resample(spacing, coregistration=coregistration_name)
+        transformed = transform(self.sample)
+        for image_dict in transformed.values():
+            if coregistration_name in image_dict.keys():
+                new_affine = np.eye(4)
+                new_affine[0, 3] = 10
+                assert_array_equal(image_dict[AFFINE], new_affine)
+            else:
+                assert_array_equal(image_dict[AFFINE], np.eye(4))
 
     def test_wrong_spacing_length(self):
         with self.assertRaises(ValueError):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import random
 import tempfile
@@ -14,7 +13,7 @@ class TorchioTestCase(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures, if any."""
-        self.dir = Path(os.path.join(tempfile.gettempdir(), os.urandom(24).hex()))
+        self.dir = Path(tempfile.gettempdir()) / '.torchio_tests'
         self.dir.mkdir(exist_ok=True)
         random.seed(42)
         np.random.seed(42)
@@ -75,7 +74,7 @@ class TorchioTestCase(unittest.TestCase):
         shutil.rmtree(self.dir)
 
     def get_ixi_tiny(self):
-        root_dir = self.dir / 'ixi_tiny'
+        root_dir = Path(tempfile.gettempdir()) / 'torchio' / 'ixi_tiny'
         return IXITiny(root_dir, download=True)
 
     def get_image_path(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import random
 import tempfile
@@ -13,7 +14,7 @@ class TorchioTestCase(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures, if any."""
-        self.dir = Path(tempfile.gettempdir()) / '.torchio_tests'
+        self.dir = Path(os.path.join(tempfile.gettempdir(), os.urandom(24).hex()))
         self.dir.mkdir(exist_ok=True)
         random.seed(42)
         np.random.seed(42)
@@ -67,7 +68,7 @@ class TorchioTestCase(unittest.TestCase):
         shutil.rmtree(self.dir)
 
     def get_ixi_tiny(self):
-        root_dir = Path(tempfile.gettempdir()) / 'torchio' / 'ixi_tiny'
+        root_dir = self.dir / 'ixi_tiny'
         return IXITiny(root_dir, download=True)
 
     def get_image_path(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,6 +19,13 @@ class TorchioTestCase(unittest.TestCase):
         random.seed(42)
         np.random.seed(42)
 
+        coregistration_matrix = np.array([
+            [1, 0, 0, 10],
+            [0, 1, 0, 0],
+            [0, 0, 1.2, 0],
+            [0, 0, 0, 1]
+        ])
+
         subject_a = Subject(
             t1=Image(self.get_image_path('t1_a'), INTENSITY),
         )
@@ -30,7 +37,7 @@ class TorchioTestCase(unittest.TestCase):
             label=Image(self.get_image_path('label_c', binary=True), LABEL),
         )
         subject_d = Subject(
-            t1=Image(self.get_image_path('t1_d'), INTENSITY),
+            t1=Image(self.get_image_path('t1_d'), INTENSITY, coregistration=coregistration_matrix),
             t2=Image(self.get_image_path('t2_d'), INTENSITY),
             label=Image(self.get_image_path('label_d', binary=True), LABEL),
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,7 @@ class TorchioTestCase(unittest.TestCase):
         random.seed(42)
         np.random.seed(42)
 
-        coregistration_matrix = np.array([
+        registration_matrix = np.array([
             [1, 0, 0, 10],
             [0, 1, 0, 0],
             [0, 0, 1.2, 0],
@@ -36,7 +36,11 @@ class TorchioTestCase(unittest.TestCase):
             label=Image(self.get_image_path('label_c', binary=True), LABEL),
         )
         subject_d = Subject(
-            t1=Image(self.get_image_path('t1_d'), INTENSITY, coregistration=coregistration_matrix),
+            t1=Image(
+                self.get_image_path('t1_d'),
+                INTENSITY,
+                pre_affine=registration_matrix,
+            ),
             t2=Image(self.get_image_path('t2_d'), INTENSITY),
             label=Image(self.get_image_path('label_d', binary=True), LABEL),
         )

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -9,7 +9,7 @@ from typing import (
 import torch
 import numpy as np
 
-from ..torchio import TypePath
+from ..torchio import TypePath, DATA, TYPE, AFFINE, PATH, STEM
 from .io import read_image
 
 
@@ -29,6 +29,10 @@ class Image(dict):
     """
 
     def __init__(self, path: TypePath, type_: str, **kwargs: Dict[str, Any]):
+        for key in (DATA, AFFINE, TYPE, PATH, STEM):
+            if key in kwargs:
+                raise ValueError(f'Key {key} is reserved. Use a different one')
+
         super().__init__(**kwargs)
         self.path = self._parse_path(path)
         self.type = type_

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -126,11 +126,20 @@ class Resample(Transform):
                 )
                 raise ValueError(message)
 
+    @staticmethod
+    def check_coregistration_key_presence(coregistration: str, images: iter):
+        for image_dict in images:
+            if coregistration in image_dict:
+                return
+        raise ValueError(f'coregistration key "{coregistration}" should be present in at least one of the sample\'s image ')
+
     def apply_transform(self, sample: Subject) -> dict:
         use_reference = self.reference_image is not None
         use_coregistration = self.coregistration is not None
-        iterable = sample.get_images_dict(intensity_only=False).items()
-        for image_name, image_dict in iterable:
+        sample_images = sample.get_images_dict(intensity_only=False)
+        if use_coregistration:
+            self.check_coregistration_key_presence(self.coregistration, sample_images.values())
+        for image_name, image_dict in sample_images.items():
             # Do not resample the reference image if there is one
             if use_reference and image_name == self.reference_image:
                 continue

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -23,10 +23,10 @@ class Resample(Transform):
             :math:`n` is specified, then :math:`s_d = s_h = s_w = n`.
             If a string is given, all images will be resampled using the image
             with that name as reference.
-        pre_affine_name: Name of the image key storing an affine matrix that
-            will be applied to the image header before resampling.
-            If ``None``, the image is resampled with an identity transform.
-            See usage in the example below.
+        pre_affine_name: Name of the *image key* (not subject key) storing an
+            affine matrix that will be applied to the image header before
+            resampling. If ``None``, the image is resampled with an identity
+            transform. See usage in the example below.
         image_interpolation: Member of :py:class:`torchio.Interpolation`.
             Supported interpolation techniques for resampling are
             :py:attr:`torchio.Interpolation.NEAREST`,
@@ -148,10 +148,10 @@ class Resample(Transform):
     def apply_transform(self, sample: Subject) -> dict:
         use_reference = self.reference_image is not None
         use_pre_affine = self.affine_name is not None
-        sample_images = sample.get_images_dict(intensity_only=False)
         if use_pre_affine:
             self.check_affine_key_presence(self.affine_name, sample)
-        for image_name, image_dict in sample_images.items():
+        images_dict = sample.get_images_dict(intensity_only=False).items()
+        for image_name, image_dict in images_dict:
             # Do not resample the reference image if there is one
             if use_reference and image_name == self.reference_image:
                 continue

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -1,9 +1,11 @@
 from numbers import Number
 from typing import Union, Tuple, Optional
+
 import torch
 import numpy as np
 import nibabel as nib
 from nibabel.processing import resample_to_output, resample_from_to
+
 from ....data.subject import Subject
 from ....torchio import LABEL, DATA, AFFINE, TYPE
 from ... import Interpolation
@@ -21,16 +23,17 @@ class Resample(Transform):
             :math:`n` is specified, then :math:`s_d = s_h = s_w = n`.
             If a string is given, all images will be resampled using the image
             with that name as reference.
-        antialiasing: (Not implemented yet).
+        pre_affine_name: Name of the image key storing an affine matrix that
+            will be applied to the image header before resampling.
+            If ``None``, the image is resampled with an identity transform.
+            See usage in the example below.
         image_interpolation: Member of :py:class:`torchio.Interpolation`.
             Supported interpolation techniques for resampling are
             :py:attr:`torchio.Interpolation.NEAREST`,
             :py:attr:`torchio.Interpolation.LINEAR` and
             :py:attr:`torchio.Interpolation.BSPLINE`.
         p: Probability that this transform will be applied.
-        coregistration: string. If not None, all affines will be multiplied using
-            the array with that name as reference before resampling, it is
-            expected that the coregistration matrix is stored as an image attribute.
+
 
     .. note:: Resampling is performed using
         :py:meth:`nibabel.processing.resample_to_output` or
@@ -38,36 +41,46 @@ class Resample(Transform):
         the target is a spacing or a reference image.
 
     Example:
+        >>> import torchio
         >>> from torchio.transforms import Resample
         >>> transform = Resample(1)          # resample all images to 1mm iso
         >>> transform = Resample((1, 1, 1))  # resample all images to 1mm iso
         >>> transform = Resample('t1')       # resample all images to 't1' image space
-
+        >>>
+        >>> # Affine matrices are added to each image
+        >>> matrix_to_mni = some_4_by_4_array  # e.g. result of registration to MNI space
+        >>> subject = torchio.Subject(
+        ...     t1=Image('t1.nii.gz', torchio.INTENSITY, to_mni=matrix_to_mni),
+        ...     mni=Image('mni_152_lin.nii.gz', torchio.INTENSITY),
+        ... )
+        >>> resample = Resample(
+        ...     'mni',  # this is subject key
+        ...     affine_name='to_mni',  # this is an image key
+        ... )
+        >>> dataset = torchio.ImagesDataset([subject], transform=resample)
+        >>> sample = dataset[0]  # sample['t1'] is now in MNI space
     """
     def __init__(
             self,
             target: Union[TypeSpacing, str],
-            antialiasing: bool = True,
             image_interpolation: Interpolation = Interpolation.LINEAR,
+            pre_affine_name: Optional[str] = None,
             p: float = 1,
-            coregistration: str = None,
             ):
         super().__init__(p=p)
-        self.target_spacing: Tuple[float, float, float]
-        self.reference_image: str
-        self.parse_target(target)
-        self.antialiasing = antialiasing
+        self.reference_image, self.target_spacing = self.parse_target(target)
         self.interpolation_order = self.parse_interpolation(
             image_interpolation)
-        self.coregistration = coregistration
+        self.affine_name = pre_affine_name
 
     def parse_target(self, target: Union[TypeSpacing, str]):
         if isinstance(target, str):
-            self.reference_image = target
-            self.target_spacing = None
+            reference_image = target
+            target_spacing = None
         else:
-            self.reference_image = None
-            self.target_spacing = self.parse_spacing(target)
+            reference_image = None
+            target_spacing = self.parse_spacing(target)
+        return reference_image, target_spacing
 
     @staticmethod
     def parse_spacing(spacing: TypeSpacing) -> Tuple[float, float, float]:
@@ -99,46 +112,45 @@ class Resample(Transform):
         return order
 
     @staticmethod
-    def check_reference_image(reference_image: str, sample: Subject):
-        if not isinstance(reference_image, str):
-            message = f'reference_image argument should be of type str, type {type(reference_image)} was given'
+    def check_affine(affine_name: str, image_dict: dict):
+        if not isinstance(affine_name, str):
+            message = (
+                'Affine name argument must be a string,'
+                f' not {type(affine_name)}'
+            )
             raise TypeError(message)
-        if reference_image not in sample.keys():
-            message = f'reference_image=\'{reference_image}\' not present in sample, only these keys were found: {sample.keys()}'
-            raise ValueError(message)
-
-    @staticmethod
-    def check_coregistration(coregistration: str, image_dict: dict):
-        if not isinstance(coregistration, str):
-            message = f'coregistration argument should be of type str, type {type(coregistration)} was given'
-            raise TypeError(message)
-        if coregistration in image_dict.keys():
-            if not isinstance(image_dict[coregistration], np.ndarray):
+        if affine_name in image_dict:
+            matrix = image_dict[affine_name]
+            if not isinstance(matrix, np.ndarray):
                 message = (
-                    f'coregistration matrix={image_dict[coregistration]} should be of type np.ndarray,'
-                    f'type {type(image_dict[coregistration])} was found'
+                    'The affine matrix must be a NumPy array,'
+                    f' not {type(matrix)}'
                 )
                 raise TypeError(message)
-            if image_dict[coregistration].shape != (4, 4):
+            if matrix.shape != (4, 4):
                 message = (
-                    f'coregistration matrix={image_dict[coregistration]} should be of shape (4, 4),'
-                    f'shape {image_dict[coregistration].shape} was found'
+                    'The affine matrix shape must be (4, 4),'
+                    f' not {matrix.shape}'
                 )
                 raise ValueError(message)
 
     @staticmethod
-    def check_coregistration_key_presence(coregistration: str, images: iter):
-        for image_dict in images:
-            if coregistration in image_dict:
+    def check_affine_key_presence(affine_name: str, sample: Subject):
+        for image_dict in sample.get_images(intensity_only=False):
+            if affine_name in image_dict:
                 return
-        raise ValueError(f'coregistration key "{coregistration}" should be present in at least one of the sample\'s image ')
+        message = (
+            f'An affine name was given ("{affine_name}"), but it was not found'
+            ' in any image in the sample'
+        )
+        raise ValueError(message)
 
     def apply_transform(self, sample: Subject) -> dict:
         use_reference = self.reference_image is not None
-        use_coregistration = self.coregistration is not None
+        use_pre_affine = self.affine_name is not None
         sample_images = sample.get_images_dict(intensity_only=False)
-        if use_coregistration:
-            self.check_coregistration_key_presence(self.coregistration, sample_images.values())
+        if use_pre_affine:
+            self.check_affine_key_presence(self.affine_name, sample)
         for image_name, image_dict in sample_images.items():
             # Do not resample the reference image if there is one
             if use_reference and image_name == self.reference_image:
@@ -150,15 +162,14 @@ class Resample(Transform):
             else:
                 interpolation_order = self.interpolation_order
 
-            # Set coregistration_matrix, coregistration key does not have to be present in every image
-            coregistration_matrix = np.eye(4)
-            if use_coregistration:
-                self.check_coregistration(self.coregistration, image_dict)
-                if self.coregistration in image_dict.keys():
-                    coregistration_matrix = image_dict[self.coregistration]
+            # Apply given affine matrix if found in image
+            if use_pre_affine and self.affine_name in image_dict:
+                self.check_affine(self.affine_name, image_dict)
+                matrix = image_dict[self.affine_name]
+                image_dict[AFFINE] = matrix @ image_dict[AFFINE]
 
             # Resample
-            args = image_dict[DATA], np.dot(coregistration_matrix, image_dict[AFFINE]), interpolation_order
+            args = image_dict[DATA], image_dict[AFFINE], interpolation_order
             if use_reference:
                 try:
                     ref_image_dict = sample[self.reference_image]


### PR DESCRIPTION
Implement feature presented in https://github.com/fepegar/torchio/issues/131 by adding a `coregistration` parameter to the Resample transform. This parameter is a string pointing to an attribute of the images the transform is applied to. If this attribute is present, it must be a 4x4 matrix.

Usage:
```python
import numpy as np
import torchio
from torchio.transforms import Resample
from torchvision.transforms import Compose

coregistration = np.eye(4)
subject = torchio.Subject(
    t1=torchio.Image(img_path, torchio.INTENSITY, coregistration=coregistration),
    label=torchio.Image(mask_path, torchio.LABEL),
    ref=torchio.Image(ref_path, torchio.INTENSITY),
)
subject_list = [subject]
transforms = [
    Resample(target='ref', coregistration='coregistration'),
]
transform = Compose(transforms)
dataset = torchio.ImagesDataset(subject_list, transform=transform)
```