### PR TITLE
Deprecate torchio.Interpolation as argument in transforms

### DIFF
--- a/docs/source/transforms/transforms.rst
+++ b/docs/source/transforms/transforms.rst
@@ -42,16 +42,16 @@ Some transforms such as
 :py:class:`~torchio.transforms.RandomMotion`
 need to interpolate intensity values during resampling.
 
-The available interpolation strategies are enumerated in
+The available interpolation strategies can be inferred from the elements of
 :class:`torchio.transforms.interpolation.Interpolation`.
 
-``Interpolation.NEAREST`` can be used for quick experimentation as it is very
+``'nearest'`` can be used for quick experimentation as it is very
 fast, but produces relatively poor results.
 
-``Interpolation.LINEAR``, defaut in TorchIO, is usually a good compromise
+``'linear'``, default in TorchIO, is usually a good compromise
 between image quality and speed to be used for data augmentation during training.
 
-Methods such as ``Interpolation.BSPLINE`` or ``Interpolation.LANCZOS`` generate
+Methods such as ``'bspline'`` or ``'lanczos'`` generate
 high-quality results, but are generally slower. They can be used to obtain
 optimal resampling results during offline data preprocessing.
 

--- a/tests/transforms/augmentation/test_random_elastic_deformation.py
+++ b/tests/transforms/augmentation/test_random_elastic_deformation.py
@@ -1,6 +1,6 @@
-import warnings
 import numpy as np
 import torchio
+from torchio import Interpolation
 from torchio.transforms import RandomElasticDeformation
 from ...utils import TorchioTestCase
 
@@ -37,9 +37,9 @@ class TestRandomElasticDeformation(TorchioTestCase):
         with self.assertRaises(TypeError):
             RandomElasticDeformation(image_interpolation=1)
 
-    def test_inputs_interpolation_string(self):
-        with self.assertRaises(TypeError):
-            RandomElasticDeformation(image_interpolation='linear')
+    def test_inputs_interpolation(self):
+        with self.assertWarns(FutureWarning):
+            RandomElasticDeformation(image_interpolation=Interpolation.LINEAR)
 
     def test_num_control_points_noint(self):
         with self.assertRaises(ValueError):

--- a/torchio/transforms/augmentation/intensity/random_motion.py
+++ b/torchio/transforms/augmentation/intensity/random_motion.py
@@ -53,7 +53,7 @@ class RandomMotion(RandomTransform):
             degrees: float = 10,
             translation: float = 10,  # in mm
             num_transforms: int = 2,
-            image_interpolation: Interpolation = Interpolation.LINEAR,
+            image_interpolation: str = 'linear',
             p: float = 1,
             seed: Optional[int] = None,
             ):
@@ -61,7 +61,7 @@ class RandomMotion(RandomTransform):
         self.degrees_range = self.parse_degrees(degrees)
         self.translation_range = self.parse_translation(translation)
         self.num_transforms = num_transforms
-        self.image_interpolation = image_interpolation
+        self.image_interpolation = self.parse_interpolation(image_interpolation)
 
     def apply_transform(self, sample: Subject) -> dict:
         random_parameters_images_dict = {}

--- a/torchio/transforms/augmentation/random_transform.py
+++ b/torchio/transforms/augmentation/random_transform.py
@@ -4,6 +4,7 @@ This is the docstring of random transform module
 
 import numbers
 from typing import Optional, Tuple, Union
+import warnings
 
 import torch
 import numpy as np
@@ -85,12 +86,19 @@ class RandomTransform(Transform):
         return self.parse_range(translation, 'translation')
 
     @staticmethod
-    def parse_interpolation(interpolation: Interpolation) -> Interpolation:
-        if not isinstance(interpolation, Interpolation):
-            message = (
-                'image_interpolation must be'
-                ' a member of torchio.Interpolation'
-            )
+    def parse_interpolation(interpolation: str) -> Interpolation:
+        if isinstance(interpolation, Interpolation):
+            message = 'Interpolation of type torchio.Interpolation is deprecated, please use a String instead.'
+            warnings.warn(message, FutureWarning)
+        elif isinstance(interpolation, str):
+            supported_values = [key.name.lower() for key in Interpolation]
+            if interpolation in supported_values:
+                interpolation = getattr(Interpolation, interpolation.upper())
+            else:
+                message = f'Interpolation {interpolation} is not among torchio supported values: {supported_values}'
+                raise AttributeError(message)
+        else:
+            message = 'image_interpolation must be a String'
             raise TypeError(message)
         return interpolation
 

--- a/torchio/transforms/augmentation/random_transform.py
+++ b/torchio/transforms/augmentation/random_transform.py
@@ -4,14 +4,13 @@ This is the docstring of random transform module
 
 import numbers
 from typing import Optional, Tuple, Union
-import warnings
 
 import torch
 import numpy as np
 
 from ...data.subject import Subject
 from ... import TypeNumber, TypeRangeFloat
-from .. import Transform, Interpolation
+from .. import Transform
 
 
 class RandomTransform(Transform):
@@ -84,23 +83,6 @@ class RandomTransform(Transform):
             translation: TypeRangeFloat,
             ) -> Tuple[float, float]:
         return self.parse_range(translation, 'translation')
-
-    @staticmethod
-    def parse_interpolation(interpolation: str) -> Interpolation:
-        if isinstance(interpolation, Interpolation):
-            message = 'Interpolation of type torchio.Interpolation is deprecated, please use a String instead.'
-            warnings.warn(message, FutureWarning)
-        elif isinstance(interpolation, str):
-            supported_values = [key.name.lower() for key in Interpolation]
-            if interpolation in supported_values:
-                interpolation = getattr(Interpolation, interpolation.upper())
-            else:
-                message = f'Interpolation {interpolation} is not among torchio supported values: {supported_values}'
-                raise AttributeError(message)
-        else:
-            message = 'image_interpolation must be a String'
-            raise TypeError(message)
-        return interpolation
 
     def check_seed(self) -> None:
         if self._seed is not None:

--- a/torchio/transforms/augmentation/spatial/random_affine.py
+++ b/torchio/transforms/augmentation/spatial/random_affine.py
@@ -48,7 +48,7 @@ class RandomAffine(RandomTransform):
         ...     degrees=(10),
         ...     isotropic=False,
         ...     default_pad_value='otsu',
-        ...     image_interpolation=Interpolation.BSPLINE,
+        ...     image_interpolation='bspline',
         ... )
         >>> transformed = transform(sample)
 
@@ -63,7 +63,7 @@ class RandomAffine(RandomTransform):
             degrees: TypeRangeFloat = 10,
             isotropic: bool = False,
             default_pad_value: Union[str, float] = 'otsu',
-            image_interpolation: Interpolation = Interpolation.LINEAR,
+            image_interpolation: str = 'linear',
             p: float = 1,
             seed: Optional[int] = None,
             ):

--- a/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
+++ b/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
@@ -46,9 +46,7 @@ class RandomElasticDeformation(RandomTransform):
             border of the coarse grid will also be set to ``0``.
             If ``2``, displacement of control points at the border of the image
             will also be set to ``0``.
-        image_interpolation: Value in
-            :py:class:`torchio.transforms.interpolation.Interpolation` (see
-            :ref:`Interpolation`).
+        image_interpolation: See :ref:`Interpolation`.
             Note that this is the interpolation used to compute voxel
             intensities when resampling using the dense displacement field.
             The value of the dense displacement at each voxel is always
@@ -114,7 +112,7 @@ class RandomElasticDeformation(RandomTransform):
             num_control_points: Union[int, Tuple[int, int, int]] = 7,
             max_displacement: Union[float, Tuple[float, float, float]] = 7.5,
             locked_borders: int = 2,
-            image_interpolation: Interpolation = Interpolation.LINEAR,
+            image_interpolation: str = 'linear',
             p: float = 1,
             seed: Optional[int] = None,
             ):

--- a/torchio/transforms/interpolation.py
+++ b/torchio/transforms/interpolation.py
@@ -7,8 +7,8 @@ class Interpolation(enum.Enum):
     """Interpolation techniques available in ITK.
 
     Example:
-        >>> from torchio.transforms import RandomAffine, Interpolation
-        >>> transform = RandomAffine(image_interpolation=Interpolation.NEAREST)
+        >>> from torchio.transforms import RandomAffine
+        >>> transform = RandomAffine(image_interpolation='nearest')
     """
     #: Interpolates image intensity at a non-integer pixel position by copying the intensity for the nearest neighbor.
     NEAREST: str = 'sitkNearestNeighbor'

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -36,8 +36,10 @@ class Resample(Transform):
             resampling. If ``None``, the image is resampled with an identity
             transform. See usage in the example below.
         image_interpolation: String that defines the interpolation technique.
-            Supported interpolation techniques for resampling are 'nearest', 'linear' and 'bspline'.
-            Member of :py:class:`torchio.Interpolation` is still supported for compatibility reasons
+            Supported interpolation techniques for resampling
+            are 'nearest','linear' and 'bspline'.
+            Using a member of :py:class:`torchio.Interpolation` is still
+            supported for backward compatibility,
             but will be removed in a future version.
         p: Probability that this transform will be applied.
 

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -112,27 +112,14 @@ class Resample(Transform):
             raise ValueError(f'Spacing must be positive, not "{spacing}"')
         return result
 
-    @staticmethod
-    def parse_interpolation(interpolation: str) -> int:
-        if isinstance(interpolation, Interpolation):
-            message = 'Interpolation of type torchio.Interpolation is deprecated, please use a String instead.'
-            warnings.warn(message, FutureWarning)
-        elif isinstance(interpolation, str):
-            supported_values = [key.name.lower() for key in Interpolation]
-            if interpolation in supported_values:
-                interpolation = getattr(Interpolation, interpolation.upper())
-            else:
-                message = f'Interpolation {interpolation} is not among torchio supported values: {supported_values}'
-                raise AttributeError(message)
-        else:
-            message = 'image_interpolation must be a String'
-            raise TypeError(message)
+    def parse_interpolation(self, interpolation: str) -> int:
+        interpolation = super().parse_interpolation(interpolation)
 
-        if interpolation == Interpolation.NEAREST:
+        if interpolation in (Interpolation.NEAREST, 'nearest'):
             order = 0
-        elif interpolation == Interpolation.LINEAR:
+        elif interpolation in (Interpolation.LINEAR, 'linear'):
             order = 1
-        elif interpolation == Interpolation.BSPLINE:
+        elif interpolation in (Interpolation.BSPLINE, 'bspline'):
             order = 3
         else:
             message = f'Interpolation not implemented yet: {interpolation}'

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -1,4 +1,5 @@
 import numbers
+import warnings
 from typing import Union
 from copy import deepcopy
 from abc import ABC, abstractmethod
@@ -11,6 +12,7 @@ from ..data.image import Image
 from ..data.subject import Subject
 from ..data.dataset import ImagesDataset
 from ..utils import nib_to_sitk, sitk_to_nib
+from .interpolation import Interpolation
 
 
 class Transform(ABC):
@@ -91,6 +93,33 @@ class Transform(ABC):
             )
             raise RuntimeError(message)
         return self._get_subject_from_tensor(tensor)
+
+    @staticmethod
+    def parse_interpolation(interpolation: str) -> Interpolation:
+        if isinstance(interpolation, Interpolation):
+            message = (
+                'Interpolation of type torchio.Interpolation'
+                ' is deprecated, please use a string instead'
+            )
+            warnings.warn(message, FutureWarning)
+        elif isinstance(interpolation, str):
+            interpolation = interpolation.lower()
+            supported_values = [key.name.lower() for key in Interpolation]
+            if interpolation in supported_values:
+                interpolation = getattr(Interpolation, interpolation.upper())
+            else:
+                message = (
+                    f'Interpolation "{interpolation}" is not among'
+                    f' the supported values: {supported_values}'
+                )
+                raise AttributeError(message)
+        else:
+            message = (
+                'image_interpolation must be a string,'
+                f' not {type(interpolation)}'
+            )
+            raise TypeError(message)
+        return interpolation
 
     @staticmethod
     def _get_subject_from_tensor(tensor: torch.Tensor) -> Subject:


### PR DESCRIPTION
Deprecate `torchio.Interpolation` as argument in transforms to make them use primitive type arguments. See https://github.com/fepegar/torchio/issues/159
- Make transforms accept `image_interpolation` parameter as a string,
- Change default `image_interpolation` values to string,
- Raise a FutureWarning when using `torchio.Interpolation` as `image_interpolation` parameter in transforms.