### PR TITLE
Make HistogramStandardization accept primitive arguments

### DIFF
--- a/tests/transforms/preprocessing/test_histogram_standardization.py
+++ b/tests/transforms/preprocessing/test_histogram_standardization.py
@@ -31,3 +31,25 @@ class TestHistogramStandardization(TorchioTestCase):
         landmarks_dict = {'image': landmarks}
         transform = HistogramStandardization(landmarks_dict)
         transform(self.dataset[0])
+
+    def test_wrong_image_key(self):
+        landmarks = np.linspace(0, 100, 13)
+        landmarks_dict = {'wrong_key': landmarks}
+        transform = HistogramStandardization(landmarks_dict)
+        with self.assertRaises(KeyError):
+            transform(self.dataset[0])
+
+    def test_with_saved_dict(self):
+        landmarks = np.linspace(0, 100, 13)
+        landmarks_dict = {'image': landmarks}
+        torch.save(landmarks_dict, self.dir / 'landmarks_dict.pth')
+        landmarks_dict = torch.load(self.dir / 'landmarks_dict.pth')
+        transform = HistogramStandardization(landmarks_dict)
+        transform(self.dataset[0])
+
+    def test_with_saved_array(self):
+        landmarks = np.linspace(0, 100, 13)
+        np.save(self.dir / 'landmarks.npy', landmarks)
+        landmarks_dict = {'image': self.dir / 'landmarks.npy'}
+        transform = HistogramStandardization(landmarks_dict)
+        transform(self.dataset[0])

--- a/torchio/transforms/preprocessing/intensity/normalization_transform.py
+++ b/torchio/transforms/preprocessing/intensity/normalization_transform.py
@@ -5,6 +5,9 @@ from ....torchio import DATA, TypeCallable
 from ... import Transform
 
 
+TypeMaskingMethod = Union[str, TypeCallable, None]
+
+
 class NormalizationTransform(Transform):
     """Base class for intensity preprocessing transforms.
 
@@ -34,7 +37,7 @@ class NormalizationTransform(Transform):
     """
     def __init__(
             self,
-            masking_method: Union[str, TypeCallable, None] = None,
+            masking_method: TypeMaskingMethod = None,
             p: float = 1,
             ):
         """

--- a/torchio/transforms/preprocessing/intensity/rescale.py
+++ b/torchio/transforms/preprocessing/intensity/rescale.py
@@ -7,7 +7,7 @@ from deprecated import deprecated
 
 from ....data.subject import Subject
 from ....torchio import DATA, TypeCallable
-from . import NormalizationTransform
+from .normalization_transform import NormalizationTransform, TypeMaskingMethod
 
 
 class RescaleIntensity(NormalizationTransform):
@@ -30,7 +30,7 @@ class RescaleIntensity(NormalizationTransform):
             self,
             out_min_max: Tuple[float, float],
             percentiles: Tuple[int, int] = (0, 100),
-            masking_method: Union[str, TypeCallable, None] = None,
+            masking_method: TypeMaskingMethod = None,
             p: float = 1,
             ):
         super().__init__(masking_method=masking_method, p=p)

--- a/torchio/transforms/preprocessing/intensity/z_normalization.py
+++ b/torchio/transforms/preprocessing/intensity/z_normalization.py
@@ -2,7 +2,7 @@ from typing import Union
 import torch
 from ....data.subject import Subject
 from ....torchio import DATA, TypeCallable
-from . import NormalizationTransform
+from .normalization_transform import NormalizationTransform, TypeMaskingMethod
 
 
 class ZNormalization(NormalizationTransform):
@@ -15,7 +15,7 @@ class ZNormalization(NormalizationTransform):
     """
     def __init__(
             self,
-            masking_method: Union[str, TypeCallable, None] = None,
+            masking_method: TypeMaskingMethod = None,
             p: float = 1,
             ):
         super().__init__(masking_method=masking_method, p=p)


### PR DESCRIPTION
Make `HistogramStandardization` accept primitive arguments by adding a method to parse `landmarks_dict` which accepts either a dictionary of NumPy arrays, a path to a dictionary and a dictionary of paths to NumPy arrays. See https://github.com/fepegar/torchio/issues/159.