### PR TITLE
Make sampler copy non image fields

### DIFF
--- a/torchio/data/sampler/sampler.py
+++ b/torchio/data/sampler/sampler.py
@@ -70,7 +70,7 @@ class ImageSampler(IterableDataset):
             index_ini: np.ndarray,
             index_fin: np.ndarray,
             ) -> dict:
-        cropped_sample = {}
+        cropped_sample = copy.deepcopy(sample)
         iterable = sample.get_images_dict(intensity_only=False).items()
         for image_name, image in iterable:
             cropped_sample[image_name] = copy.deepcopy(image)


### PR DESCRIPTION
Here is a small PR to avoir loss of meta data information when creating patches. 

Previous behaviour: only images (of type `INTENSITY` or `LABEL`) were processed and saved in the `cropped_sample` leading to the loss of any non image property of the sample.

New behaviour: all properties are copied and images are updated.