### PR TITLE
Swap tensor.ndim for tensor.dim()

### DIFF
--- a/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
+++ b/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
@@ -242,7 +242,7 @@ class RandomElasticDeformation(RandomTransform):
             bspline_params: np.ndarray,
             interpolation: Interpolation,
             ) -> torch.Tensor:
-        assert tensor.ndim == 4
+        assert tensor.dim() == 4
         assert len(tensor) == 1
         image = self.nib_to_sitk(tensor[0], affine)
         floating = reference = image


### PR DESCRIPTION
Tensor.ndim is an alias for tensor.dim() but is only present in newer torch versions. 
This change would ensure backward compatibility with no impact on current behaviour.