### PR TITLE
Fix non integer labels in Colin 27 version 2008

### DIFF
--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -246,6 +246,8 @@ class Image(dict):
             :math:`(1, D_{in}, H_{in}, W_{in})`
             and a 2D 4x4 affine matrix
         """
+        if self._loaded:
+            return
         if self.path is None:
             return
         tensor, affine = read_image(self.path)

--- a/torchio/datasets/mni/colin.py
+++ b/torchio/datasets/mni/colin.py
@@ -63,5 +63,5 @@ class Colin27(SubjectMNI):
                 t1=Image(t1),
                 t2=Image(t2),
                 pd=Image(pd),
-                cls=cls_image,
+                cls=Image(label, type=LABEL),
             )

--- a/torchio/datasets/mni/colin.py
+++ b/torchio/datasets/mni/colin.py
@@ -1,15 +1,25 @@
 import urllib.parse
 from torchvision.datasets.utils import download_and_extract_archive
 from ...utils import get_torchio_cache_dir
-from ... import Image, LABEL
+from ... import Image, LABEL, DATA
 from .mni import SubjectMNI
 
 
 class Colin27(SubjectMNI):
-    """Colin27 MNI template.
+    r"""Colin27 MNI template.
+
+    More information can be found in the website of the
+    `1998 <http://nist.mni.mcgill.ca/?p=935>`_ and
+    `2008 <http://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27Highres>`_
+    versions.
 
     Arguments:
-        version: Template year. It can ``1998`` or ``2008``.
+        version: Template year. It can be ``1998`` or ``2008``.
+
+    .. warning:: The resolution of the ``2008`` version is quite high. The
+        subject instance will contain four images of size
+        :math:`362 \times 434 \times 362`, therefore applying a transform to
+        it might take longer than expected.
     """
     def __init__(self, version=1998):
         if version not in (1998, 2008):
@@ -43,9 +53,13 @@ class Colin27(SubjectMNI):
                 download_root / f'colin27_{name}_tal_hires.nii'
                 for name in ('t1', 't2', 'pd', 'cls')
             ]
+            # Labels do not seem to be encoded correctly in this file
+            # See https://github.com/fepegar/torchio/issues/220
+            cls_image = Image(label, type=LABEL)
+            cls_image[DATA] = cls_image[DATA].round()
             super().__init__(
                 t1=Image(t1),
                 t2=Image(t2),
                 pd=Image(pd),
-                cls=Image(label, type=LABEL),
+                cls=cls_image,
             )

--- a/torchio/datasets/mni/colin.py
+++ b/torchio/datasets/mni/colin.py
@@ -37,6 +37,12 @@ class Colin27(SubjectMNI):
                 download_root=download_root,
                 filename=self.filename,
             )
+            # Fix label map (https://github.com/fepegar/torchio/issues/220)
+            if version == 2008:
+                path = download_root / 'colin27_cls_tal_hires.nii'
+                cls_image = Image(path, type=LABEL)
+                cls_image[DATA] = cls_image[DATA].round().byte()
+                cls_image.save(path)
 
         if version == 1998:
             t1, head, mask = [
@@ -53,10 +59,6 @@ class Colin27(SubjectMNI):
                 download_root / f'colin27_{name}_tal_hires.nii'
                 for name in ('t1', 't2', 'pd', 'cls')
             ]
-            # Labels do not seem to be encoded correctly in this file
-            # See https://github.com/fepegar/torchio/issues/220
-            cls_image = Image(label, type=LABEL)
-            cls_image[DATA] = cls_image[DATA].round()
             super().__init__(
                 t1=Image(t1),
                 t2=Image(t2),


### PR DESCRIPTION
Fixes #220.

The downside of this approach is that the label map has to be loaded so that the values are changed.

I also had to modify the `Image` class so that the data is not loaded again by `ImagesDataset.__getitem__`.

An alternative (better?) solution to modifying the data after loading in the `Colin27` class is to modify the image right after downloading.