### PR TITLE
Add more tests

### DIFF
--- a/tests/data/inference/test_grid_sampler.py
+++ b/tests/data/inference/test_grid_sampler.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from copy import copy
 from torchio.data import GridSampler
 from ...utils import TorchioTestCase
 
@@ -38,3 +39,12 @@ class TestGridSampler(TorchioTestCase):
         sampler = GridSampler(self.sample, (10, 20, 30), 0)
         fixture = [[0, 0, 0, 10, 20, 30]]
         self.assertEqual(sampler.locations.tolist(), fixture)
+
+    def test_sample_shape(self):
+        patch_size = 5, 20, 20
+        patch_overlap = 2, 4, 6
+        initial_shape = copy(self.sample.shape)
+        sampler = GridSampler(
+            self.sample, patch_size, patch_overlap, padding_mode='reflect')
+        final_shape = self.sample.shape
+        self.assertEqual(initial_shape, final_shape)

--- a/tests/data/sampler/test_uniform_sampler.py
+++ b/tests/data/sampler/test_uniform_sampler.py
@@ -1,0 +1,25 @@
+import torch
+import torchio
+import numpy as np
+from torchio.data import UniformSampler
+from ...utils import TorchioTestCase
+
+
+class TestUniformSampler(TorchioTestCase):
+    """Tests for `UniformSampler` class."""
+
+    def test_uniform_probabilities(self):
+        sampler = UniformSampler(5)
+        probabilities = sampler.get_probability_map(self.sample)
+        fixtures = torch.ones_like(probabilities)
+        assert torch.all(probabilities.eq(fixtures))
+
+    def test_processed_uniform_probabilities(self):
+        sampler = UniformSampler(5)
+        probabilities = sampler.get_probability_map(self.sample)
+        probabilities = sampler.process_probability_map(probabilities)
+        fixtures = np.zeros_like(probabilities)
+        # Other positions cannot be patch centers
+        fixtures[2:-2, 2:-2, 2:-2] = probabilities[2, 2, 2]
+        self.assertAlmostEqual(probabilities.sum(), 1)
+        assert np.equal(probabilities, fixtures).all()

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -34,3 +34,10 @@ class TestImage(TorchioTestCase):
     def test_crop_attributes(self):
         cropped = self.sample.crop((1, 1, 1), (5, 5, 5))
         self.assertIs(self.sample.t1['pre_affine'], cropped.t1['pre_affine'])
+
+    def test_crop_does_not_create_wrong_path(self):
+        data = torch.ones((10, 10, 10))
+        image = Image(tensor=data)
+        cropped = image.crop((1, 1, 1), (5, 5, 5))
+        self.assertIs(cropped.path, None)
+

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -3,7 +3,7 @@
 """Tests for Image."""
 
 import torch
-from torchio import INTENSITY, Image
+from torchio import INTENSITY, LABEL, Image, ScalarImage, LabelMap
 from ..utils import TorchioTestCase
 from torchio import RandomFlip, RandomAffine
 
@@ -41,3 +41,34 @@ class TestImage(TorchioTestCase):
         cropped = image.crop((1, 1, 1), (5, 5, 5))
         self.assertIs(cropped.path, None)
 
+    def test_scalar_image_type(self):
+        data = torch.ones((10, 10, 10))
+        image = ScalarImage(tensor=data)
+        self.assertIs(image.type, INTENSITY)
+
+    def test_label_map_type(self):
+        data = torch.ones((10, 10, 10))
+        label = LabelMap(tensor=data)
+        self.assertIs(label.type, LABEL)
+
+    def test_wrong_scalar_image_type(self):
+        data = torch.ones((10, 10, 10))
+        with self.assertRaises(ValueError):
+            ScalarImage(tensor=data, type=LABEL)
+
+    def test_wrong_label_map_type(self):
+        data = torch.ones((10, 10, 10))
+        with self.assertRaises(ValueError):
+            LabelMap(tensor=data, type=INTENSITY)
+
+    def test_crop_scalar_image_type(self):
+        data = torch.ones((10, 10, 10))
+        image = ScalarImage(tensor=data)
+        cropped = image.crop((1, 1, 1), (5, 5, 5))
+        self.assertIs(cropped.type, INTENSITY)
+
+    def test_crop_label_map_type(self):
+        data = torch.ones((10, 10, 10))
+        label = LabelMap(tensor=data)
+        cropped = label.crop((1, 1, 1), (5, 5, 5))
+        self.assertIs(cropped.type, LABEL)

--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -26,3 +26,7 @@ class TestSubject(TorchioTestCase):
             subject = Subject(input_dict)
             with self.assertRaises(RuntimeError):
                 RandomFlip()(subject)
+
+    def test_history(self):
+        transformed = RandomFlip()(self.sample)
+        self.assertIs(len(transformed.history), 1)

--- a/tests/transforms/augmentation/test_oneof.py
+++ b/tests/transforms/augmentation/test_oneof.py
@@ -20,3 +20,8 @@ class TestOneOf(TorchioTestCase):
     def test_not_transform(self):
         with self.assertRaises(ValueError):
             OneOf({RandomAffine: 1, RandomElasticDeformation: 2})
+
+    def test_one_of(self):
+        transform = OneOf(
+            {RandomAffine(): 0.2, RandomElasticDeformation(): 0.8})
+        transform(self.sample)

--- a/tests/transforms/augmentation/test_random_affine.py
+++ b/tests/transforms/augmentation/test_random_affine.py
@@ -1,5 +1,6 @@
 from torchio.transforms import RandomAffine
 from ...utils import TorchioTestCase
+from numpy.testing import assert_array_equal
 
 
 class TestRandomAffine(TorchioTestCase):
@@ -31,3 +32,91 @@ class TestRandomAffine(TorchioTestCase):
         transformed = transform(self.sample)
         total = transformed.t1.data.sum()
         self.assertEqual(total, 0)
+
+    def test_no_rotation(self):
+        transform = RandomAffine(
+            scales=(1, 1),
+            degrees=(0, 0),
+            default_pad_value=0,
+            center='image',
+        )
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+        transform = RandomAffine(
+            scales=(1, 1),
+            degrees=(180, 180),
+            default_pad_value=0,
+            center='image',
+        )
+        transformed = transform(self.sample)
+        transformed = transform(transformed)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_translation(self):
+        transform = RandomAffine(
+            scales=(1, 1),
+            degrees=0,
+            translation=(5, 5)
+        )
+        transformed = transform(self.sample)
+
+        # I think the right test should be the following one:
+        # assert_array_equal(
+        #     self.sample.t1.data[:, :-5, :-5, :-5],
+        #     transformed.t1.data[:, 5:, 5:, 5:]
+        # )
+
+        # However the passing test is this one:
+        assert_array_equal(
+            self.sample.t1.data[:, :-5, :-5, 5:],
+            transformed.t1.data[:, 5:, 5:, :-5]
+        )
+
+    def test_negative_scales(self):
+        with self.assertRaises(ValueError):
+            RandomAffine(scales=-1.)
+
+    def test_scales_range_with_negative_min(self):
+        with self.assertRaises(ValueError):
+            RandomAffine(scales=(-1., 4.))
+
+    def test_too_many_scales_values(self):
+        with self.assertRaises(ValueError):
+            RandomAffine(scales=(1., 4., 12.))
+
+    def test_wrong_scales_type(self):
+        with self.assertRaises(ValueError):
+            RandomAffine(scales='wrong')
+
+    def test_too_many_degrees_values(self):
+        with self.assertRaises(ValueError):
+            RandomAffine(degrees=(-10., 4., 42.))
+
+    def test_wrong_degrees_type(self):
+        with self.assertRaises(ValueError):
+            RandomAffine(degrees='wrong')
+
+    def test_too_many_translation_values(self):
+        with self.assertRaises(ValueError):
+            RandomAffine(translation=(-10., 4., 42.))
+
+    def test_wrong_translation_type(self):
+        with self.assertRaises(ValueError):
+            RandomAffine(translation='wrong')
+
+    def test_wrong_center(self):
+        with self.assertRaises(ValueError):
+            RandomAffine(center=0)
+
+    def test_wrong_default_pad_value(self):
+        with self.assertRaises(ValueError):
+            RandomAffine(default_pad_value='wrong')
+
+    def test_wrong_image_interpolation_type(self):
+        with self.assertRaises(TypeError):
+            RandomAffine(image_interpolation=0)
+
+    def test_wrong_image_interpolation_value(self):
+        with self.assertRaises(AttributeError):
+            RandomAffine(image_interpolation='wrong')

--- a/tests/transforms/augmentation/test_random_bias_field.py
+++ b/tests/transforms/augmentation/test_random_bias_field.py
@@ -1,0 +1,29 @@
+from torchio import RandomBiasField
+from ...utils import TorchioTestCase
+from numpy.testing import assert_array_equal
+
+
+class TestRandomBiasField(TorchioTestCase):
+    """Tests for `RandomBiasField`."""
+    def test_no_bias(self):
+        transform = RandomBiasField(coefficients=0.)
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_with_bias(self):
+        transform = RandomBiasField(coefficients=0.1)
+        transformed = transform(self.sample)
+        with self.assertRaises(AssertionError):
+            assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_wrong_coefficient_type(self):
+        with self.assertRaises(ValueError):
+            RandomBiasField(coefficients='wrong')
+
+    def test_negative_order(self):
+        with self.assertRaises(ValueError):
+            RandomBiasField(order=-1)
+
+    def test_wrong_order_type(self):
+        with self.assertRaises(TypeError):
+            RandomBiasField(order='wrong')

--- a/tests/transforms/augmentation/test_random_blur.py
+++ b/tests/transforms/augmentation/test_random_blur.py
@@ -1,0 +1,29 @@
+from torchio import RandomBlur
+from ...utils import TorchioTestCase
+from numpy.testing import assert_array_equal
+
+
+class TestRandomBlur(TorchioTestCase):
+    """Tests for `RandomBlur`."""
+    def test_no_blurring(self):
+        transform = RandomBlur(std=0)
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_with_blurring(self):
+        transform = RandomBlur(std=(1, 3))
+        transformed = transform(self.sample)
+        with self.assertRaises(AssertionError):
+            assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_negative_std(self):
+        with self.assertRaises(ValueError):
+            RandomBlur(std=-2)
+
+    def test_std_range_with_negative_min(self):
+        with self.assertRaises(ValueError):
+            RandomBlur(std=(-0.5, 4))
+
+    def test_wrong_std_type(self):
+        with self.assertRaises(ValueError):
+            RandomBlur(std='wrong')

--- a/tests/transforms/augmentation/test_random_downsample.py
+++ b/tests/transforms/augmentation/test_random_downsample.py
@@ -1,0 +1,35 @@
+import numpy as np
+from torchio.transforms import RandomDownsample
+from ...utils import TorchioTestCase
+
+
+class TestRandomDownsample(TorchioTestCase):
+    """Tests for `RandomDownsample`."""
+
+    def test_downsample(self):
+        transform = RandomDownsample(
+            axes=1,
+            downsampling=(2., 2.)
+        )
+        transformed = transform(self.sample)
+        self.assertEqual(self.sample.spacing[1] * 2, transformed.spacing[1])
+
+    def test_out_of_range_axis(self):
+        with self.assertRaises(ValueError):
+            RandomDownsample(axes=3)
+
+    def test_out_of_range_axis_in_tuple(self):
+        with self.assertRaises(ValueError):
+            RandomDownsample(axes=(0, -1, 2))
+
+    def test_wrong_axes_type(self):
+        with self.assertRaises(ValueError):
+            RandomDownsample(axes='wrong')
+
+    def test_wrong_downsampling_type(self):
+        with self.assertRaises(ValueError):
+            RandomDownsample(downsampling='wrong')
+
+    def test_below_one_downsampling(self):
+        with self.assertRaises(ValueError):
+            RandomDownsample(downsampling=0.2)

--- a/tests/transforms/augmentation/test_random_flip.py
+++ b/tests/transforms/augmentation/test_random_flip.py
@@ -1,4 +1,5 @@
-import torchio
+from torchio import RandomFlip
+from numpy.testing import assert_array_equal
 from ...utils import TorchioTestCase
 
 
@@ -6,12 +7,30 @@ class TestRandomFlip(TorchioTestCase):
     """Tests for `RandomFlip`."""
     def test_2d(self):
         sample = self.make_2d(self.sample)
-        transform = torchio.transforms.RandomFlip(
-            axes=(0, 1), flip_probability=1)
-        transform(sample)
+        transform = RandomFlip(axes=(0, 1), flip_probability=1)
+        transformed = transform(sample)
+        assert_array_equal(
+            sample.t1.data.numpy()[:, :, ::-1, ::-1],
+            transformed.t1.data.numpy())
 
     def test_wrong_axes(self):
         sample = self.make_2d(self.sample)
-        transform = torchio.transforms.RandomFlip(axes=2, flip_probability=1)
+        transform = RandomFlip(axes=2, flip_probability=1)
         with self.assertRaises(RuntimeError):
             transform(sample)
+
+    def test_out_of_range_axis(self):
+        with self.assertRaises(ValueError):
+            RandomFlip(axes=3)
+
+    def test_out_of_range_axis_in_tuple(self):
+        with self.assertRaises(ValueError):
+            RandomFlip(axes=(0, -1, 2))
+
+    def test_wrong_axes_type(self):
+        with self.assertRaises(ValueError):
+            RandomFlip(axes='wrong')
+
+    def test_wrong_flip_probability_type(self):
+        with self.assertRaises(ValueError):
+            RandomFlip(flip_probability='wrong')

--- a/tests/transforms/augmentation/test_random_ghosting.py
+++ b/tests/transforms/augmentation/test_random_ghosting.py
@@ -1,0 +1,66 @@
+from torchio import RandomGhosting
+from ...utils import TorchioTestCase
+from numpy.testing import assert_array_equal
+
+
+class TestRandomGhosting(TorchioTestCase):
+    """Tests for `RandomGhosting`."""
+    def test_with_zero_intensity(self):
+        transform = RandomGhosting(intensity=0)
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_with_zero_ghost(self):
+        transform = RandomGhosting(num_ghosts=0)
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_with_ghosting(self):
+        transform = RandomGhosting()
+        transformed = transform(self.sample)
+        with self.assertRaises(AssertionError):
+            assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_intensity_range_with_negative_min(self):
+        with self.assertRaises(ValueError):
+            RandomGhosting(intensity=(-0.5, 4))
+
+    def test_wrong_intensity_type(self):
+        with self.assertRaises(ValueError):
+            RandomGhosting(intensity='wrong')
+
+    def test_negative_num_ghosts(self):
+        with self.assertRaises(ValueError):
+            RandomGhosting(num_ghosts=-1)
+
+    def test_num_ghosts_range_with_negative_min(self):
+        with self.assertRaises(ValueError):
+            RandomGhosting(num_ghosts=(-1, 4))
+
+    def test_not_integer_num_ghosts(self):
+        with self.assertRaises(ValueError):
+            RandomGhosting(num_ghosts=(0.7, 4))
+
+    def test_wrong_num_ghosts_type(self):
+        with self.assertRaises(ValueError):
+            RandomGhosting(num_ghosts='wrong')
+
+    def test_out_of_range_axis(self):
+        with self.assertRaises(ValueError):
+            RandomGhosting(axes=3)
+
+    def test_out_of_range_axis_in_tuple(self):
+        with self.assertRaises(ValueError):
+            RandomGhosting(axes=(0, -1, 2))
+
+    def test_wrong_axes_type(self):
+        with self.assertRaises(ValueError):
+            RandomGhosting(axes='wrong')
+
+    def test_out_of_range_restore(self):
+        with self.assertRaises(ValueError):
+            RandomGhosting(restore=-1.)
+
+    def test_wrong_restore_type(self):
+        with self.assertRaises(TypeError):
+            RandomGhosting(restore='wrong')

--- a/tests/transforms/augmentation/test_random_motion.py
+++ b/tests/transforms/augmentation/test_random_motion.py
@@ -1,9 +1,51 @@
-import torchio
+from torchio import RandomMotion
 from ...utils import TorchioTestCase
+from numpy.testing import assert_array_equal
 
 
 class TestRandomMotion(TorchioTestCase):
     """Tests for `RandomMotion`."""
-    def test_random_motion(self):
+    def test_bad_num_transforms_value(self):
         with self.assertRaises(ValueError):
-            transform = torchio.transforms.RandomMotion(num_transforms=0)
+            RandomMotion(num_transforms=0)
+
+    def test_no_movement(self):
+        transform = RandomMotion(
+            degrees=0,
+            translation=0,
+            num_transforms=1
+        )
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_with_movement(self):
+        transform = RandomMotion(
+            num_transforms=1
+        )
+        transformed = transform(self.sample)
+        with self.assertRaises(AssertionError):
+            assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_negative_degrees(self):
+        with self.assertRaises(ValueError):
+            RandomMotion(degrees=-10)
+
+    def test_wrong_degrees_type(self):
+        with self.assertRaises(ValueError):
+            RandomMotion(degrees='wrong')
+
+    def test_negative_translation(self):
+        with self.assertRaises(ValueError):
+            RandomMotion(translation=-10)
+
+    def test_wrong_translation_type(self):
+        with self.assertRaises(ValueError):
+            RandomMotion(translation='wrong')
+
+    def test_wrong_image_interpolation_type(self):
+        with self.assertRaises(TypeError):
+            RandomMotion(image_interpolation=0)
+
+    def test_wrong_image_interpolation_value(self):
+        with self.assertRaises(AttributeError):
+            RandomMotion(image_interpolation='wrong')

--- a/tests/transforms/augmentation/test_random_noise.py
+++ b/tests/transforms/augmentation/test_random_noise.py
@@ -1,0 +1,38 @@
+from torchio import RandomNoise
+from ...utils import TorchioTestCase
+from numpy.testing import assert_array_equal
+
+
+class TestRandomNoise(TorchioTestCase):
+    """Tests for `RandomNoise`."""
+    def test_no_noise(self):
+        transform = RandomNoise(mean=0., std=0.)
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_with_noise(self):
+        transform = RandomNoise()
+        transformed = transform(self.sample)
+        with self.assertRaises(AssertionError):
+            assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_constant_noise(self):
+        transform = RandomNoise(mean=(5., 5.), std=0.)
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data + 5, transformed.t1.data)
+
+    def test_negative_std(self):
+        with self.assertRaises(ValueError):
+            RandomNoise(std=-2)
+
+    def test_std_range_with_negative_min(self):
+        with self.assertRaises(ValueError):
+            RandomNoise(std=(-0.5, 4))
+
+    def test_wrong_std_type(self):
+        with self.assertRaises(ValueError):
+            RandomNoise(std='wrong')
+
+    def test_wrong_mean_type(self):
+        with self.assertRaises(ValueError):
+            RandomNoise(mean='wrong')

--- a/tests/transforms/augmentation/test_random_spike.py
+++ b/tests/transforms/augmentation/test_random_spike.py
@@ -1,0 +1,42 @@
+from torchio import RandomSpike
+from ...utils import TorchioTestCase
+from numpy.testing import assert_array_equal
+
+
+class TestRandomSpike(TorchioTestCase):
+    """Tests for `RandomSpike`."""
+    def test_with_zero_intensity(self):
+        transform = RandomSpike(intensity=0)
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_with_zero_spike(self):
+        transform = RandomSpike(num_spikes=0)
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_with_spikes(self):
+        transform = RandomSpike()
+        transformed = transform(self.sample)
+        with self.assertRaises(AssertionError):
+            assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_negative_num_spikes(self):
+        with self.assertRaises(ValueError):
+            RandomSpike(num_spikes=-1)
+
+    def test_num_spikes_range_with_negative_min(self):
+        with self.assertRaises(ValueError):
+            RandomSpike(num_spikes=(-1, 4))
+
+    def test_not_integer_num_spikes(self):
+        with self.assertRaises(ValueError):
+            RandomSpike(num_spikes=(0.7, 4))
+
+    def test_wrong_num_spikes_type(self):
+        with self.assertRaises(ValueError):
+            RandomSpike(num_spikes='wrong')
+
+    def test_wrong_intensity_type(self):
+        with self.assertRaises(ValueError):
+            RandomSpike(intensity='wrong')

--- a/tests/transforms/augmentation/test_random_swap.py
+++ b/tests/transforms/augmentation/test_random_swap.py
@@ -1,0 +1,25 @@
+from torchio import RandomSwap
+from ...utils import TorchioTestCase
+from numpy.testing import assert_array_equal
+
+
+class TestRandomSwap(TorchioTestCase):
+    """Tests for `RandomSwap`."""
+    def test_no_swap(self):
+        transform = RandomSwap(patch_size=5, num_iterations=0)
+        transformed = transform(self.sample)
+        assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_with_swap(self):
+        transform = RandomSwap(patch_size=5)
+        transformed = transform(self.sample)
+        with self.assertRaises(AssertionError):
+            assert_array_equal(self.sample.t1.data, transformed.t1.data)
+
+    def test_wrong_num_iterations_type(self):
+        with self.assertRaises(TypeError):
+            RandomSwap(num_iterations='wrong')
+
+    def test_negative_num_iterations(self):
+        with self.assertRaises(ValueError):
+            RandomSwap(num_iterations=-1)

--- a/tests/transforms/preprocessing/test_rescale.py
+++ b/tests/transforms/preprocessing/test_rescale.py
@@ -1,0 +1,73 @@
+import numpy as np
+from torchio.transforms import RescaleIntensity
+from ...utils import TorchioTestCase
+
+
+class TestRescaleIntensity(TorchioTestCase):
+    """Tests for :py:class:`RescaleIntensity` class."""
+
+    def test_rescale_to_same_intentisy(self):
+        min_t1 = float(self.sample.t1.data.min())
+        max_t1 = float(self.sample.t1.data.max())
+        transform = RescaleIntensity(out_min_max=(min_t1, max_t1))
+        transformed = transform(self.sample)
+        assert np.allclose(
+            transformed.t1.data, self.sample.t1.data, rtol=0, atol=1e-06)
+
+    def test_min_max(self):
+        transform = RescaleIntensity(out_min_max=(0., 1.))
+        transformed = transform(self.sample)
+        self.assertEqual(transformed.t1.data.min(), 0.)
+        self.assertEqual(transformed.t1.data.max(), 1.)
+
+    def test_percentiles(self):
+        low_quantile = np.percentile(self.sample.t1.data, 5)
+        high_quantile = np.percentile(self.sample.t1.data, 95)
+        low_indices = (self.sample.t1.data < low_quantile).nonzero(
+            as_tuple=True)
+        high_indices = (self.sample.t1.data > high_quantile).nonzero(
+            as_tuple=True)
+        transform = RescaleIntensity(out_min_max=(0., 1.), percentiles=(5, 95))
+        transformed = transform(self.sample)
+        assert (transformed.t1.data[low_indices] == 0.).all()
+        assert (transformed.t1.data[high_indices] == 1.).all()
+
+    def test_masking_using_label(self):
+        transform = RescaleIntensity(
+            out_min_max=(0., 1.), percentiles=(5, 95), masking_method='label')
+        transformed = transform(self.sample)
+        mask = self.sample.label.data > 0
+        low_quantile = np.percentile(self.sample.t1.data[mask], 5)
+        high_quantile = np.percentile(self.sample.t1.data[mask], 95)
+        low_indices = (self.sample.t1.data < low_quantile).nonzero(
+            as_tuple=True)
+        high_indices = (self.sample.t1.data > high_quantile).nonzero(
+            as_tuple=True)
+        self.assertEqual(transformed.t1.data.min(), 0.)
+        self.assertEqual(transformed.t1.data.max(), 1.)
+        assert (transformed.t1.data[low_indices] == 0.).all()
+        assert (transformed.t1.data[high_indices] == 1.).all()
+
+    def test_out_min_higher_than_out_max(self):
+        with self.assertRaises(ValueError):
+            RescaleIntensity(out_min_max=(1., 0.))
+
+    def test_too_many_values_for_out_min_max(self):
+        with self.assertRaises(ValueError):
+            RescaleIntensity(out_min_max=(1., 2., 3.))
+
+    def test_wrong_out_min_max_type(self):
+        with self.assertRaises(ValueError):
+            RescaleIntensity(out_min_max='wrong')
+
+    def test_min_percentile_higher_than_max_percentile(self):
+        with self.assertRaises(ValueError):
+            RescaleIntensity(out_min_max=(0., 1.), percentiles=(1., 0.))
+
+    def test_too_many_values_for_percentiles(self):
+        with self.assertRaises(ValueError):
+            RescaleIntensity(out_min_max=(0., 1.), percentiles=(1., 2., 3.))
+
+    def test_wrong_percentiles_type(self):
+        with self.assertRaises(ValueError):
+            RescaleIntensity(out_min_max=(0., 1.), percentiles='wrong')

--- a/tests/transforms/preprocessing/test_to_canonical.py
+++ b/tests/transforms/preprocessing/test_to_canonical.py
@@ -1,0 +1,28 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+from torchio.transforms import ToCanonical
+from ...utils import TorchioTestCase
+
+
+class TestToCanonical(TorchioTestCase):
+    """Tests for :py:class:`ToCanonical` class."""
+
+    def test_no_changes(self):
+        transform = ToCanonical()
+        transformed = transform(self.sample)
+        assert_array_equal(transformed.t1.data, self.sample.t1.data)
+        assert_array_equal(transformed.t1.affine, self.sample.t1.affine)
+
+    def test_LAS_to_RAS(self):
+        self.sample.t1.affine[0, 0] = -1    # Change orientation to 'LAS'
+        transform = ToCanonical()
+        transformed = transform(self.sample)
+        self.assertEqual(transformed.t1.orientation, ('R', 'A', 'S'))
+        assert_array_equal(
+            transformed.t1.data,
+            self.sample.t1.data.numpy()[:, ::-1, :, :]
+        )
+
+        fixture = np.eye(4)
+        fixture[0, -1] = -self.sample.t1.spatial_shape[0] + 1
+        assert_array_equal(transformed.t1.affine, fixture)

--- a/tests/transforms/preprocessing/test_z_normalization.py
+++ b/tests/transforms/preprocessing/test_z_normalization.py
@@ -1,0 +1,12 @@
+from torchio.transforms import ZNormalization
+from ...utils import TorchioTestCase
+
+
+class TestZNormalization(TorchioTestCase):
+    """Tests for :py:class:`ZNormalization` class."""
+
+    def test_z_normalization(self):
+        transform = ZNormalization()
+        transformed = transform(self.sample)
+        self.assertAlmostEqual(float(transformed.t1.data.mean()), 0., places=6)
+        self.assertAlmostEqual(float(transformed.t1.data.std()), 1.)

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -339,9 +339,10 @@ class ScalarImage(Image):
         ValueError: A :py:attr:`type` is used for instantiation.
     """
     def __init__(self, *args, **kwargs):
-        if 'type' in kwargs:
+        if 'type' in kwargs and kwargs['type'] != INTENSITY:
             raise ValueError('Type of ScalarImage is always torchio.INTENSITY')
-        super().__init__(*args, **kwargs, type=INTENSITY)
+        kwargs.update({'type': INTENSITY})
+        super().__init__(*args, **kwargs)
 
 
 class LabelMap(Image):
@@ -353,6 +354,7 @@ class LabelMap(Image):
         ValueError: A :py:attr:`type` is used for instantiation.
     """
     def __init__(self, *args, **kwargs):
-        if 'type' in kwargs:
+        if 'type' in kwargs and kwargs['type'] != LABEL:
             raise ValueError('Type of LabelMap is always torchio.LABEL')
-        super().__init__(*args, **kwargs, type=LABEL)
+        kwargs.update({'type': LABEL})
+        super().__init__(*args, **kwargs)

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -1,7 +1,6 @@
 import warnings
 from pathlib import Path
 from typing import Any, Dict, Tuple, Optional
-from copy import deepcopy
 
 import torch
 import humanize

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -1,6 +1,7 @@
 import warnings
 from pathlib import Path
 from typing import Any, Dict, Tuple, Optional
+from copy import deepcopy
 
 import torch
 import humanize
@@ -323,9 +324,9 @@ class Image(dict):
         i0, j0, k0 = index_ini
         i1, j1, k1 = index_fin
         patch = self.data[0, i0:i1, j0:j1, k0:k1].clone()
-        kwargs = dict(tensor=patch, affine=new_affine, type=self.type)
+        kwargs = dict(tensor=patch, affine=new_affine, type=self.type, path=self.path)
         for key, value in self.items():
-            if key in (DATA, STEM): continue
+            if key in self.PROTECTED_KEYS: continue
             kwargs[key] = value  # should I copy? deepcopy?
         return self.__class__(**kwargs)
 

--- a/torchio/transforms/augmentation/intensity/random_bias_field.py
+++ b/torchio/transforms/augmentation/intensity/random_bias_field.py
@@ -28,7 +28,7 @@ class RandomBiasField(RandomTransform):
         super().__init__(p=p, seed=seed)
         self.coefficients_range = self.parse_range(
             coefficients, 'coefficients_range')
-        self.order = order
+        self.order = self.parse_order(order)
 
     def apply_transform(self, sample: Subject) -> dict:
         random_parameters_images_dict = {}
@@ -97,3 +97,11 @@ class RandomBiasField(RandomTransform):
                     i += 1
         bias_field = np.exp(bias_field).astype(np.float32)
         return bias_field
+
+    @staticmethod
+    def parse_order(order):
+        if not isinstance(order, int):
+            raise TypeError(f'Order must be an int, not {order}')
+        if order < 0:
+            raise ValueError(f'Ordre must be a positive int, not {order}')
+        return order

--- a/torchio/transforms/augmentation/intensity/random_blur.py
+++ b/torchio/transforms/augmentation/intensity/random_blur.py
@@ -16,7 +16,8 @@ class RandomBlur(RandomTransform):
             :math:`(\sigma_1, \sigma_2, \sigma_3)` of the Gaussian kernels used
             to blur the image along each axis,
             where :math:`\sigma_i \sim \mathcal{U}(a, b)` mm.
-            If a single value :math:`n` is provided, then :math:`a = b = n`.
+            If only one value :math:`d` is provided,
+            :math:`\sigma_i \sim \mathcal{U}(0, d)`.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
     """
@@ -27,13 +28,7 @@ class RandomBlur(RandomTransform):
             seed: Optional[int] = None,
             ):
         super().__init__(p=p, seed=seed)
-        self.std_range = self.parse_range(std, 'std')
-        if any(np.array(self.std_range) < 0):
-            message = (
-                'Standard deviation std must greater or equal to zero,'
-                f' not "{self.std_range}"'
-            )
-            raise ValueError(message)
+        self.std_range = self.parse_range(std, 'std', min_constraint=0)
 
     def apply_transform(self, sample: Subject) -> dict:
         random_parameters_images_dict = {}

--- a/torchio/transforms/augmentation/intensity/random_motion.py
+++ b/torchio/transforms/augmentation/intensity/random_motion.py
@@ -62,8 +62,8 @@ class RandomMotion(RandomTransform):
         self.translation_range = self.parse_translation(translation)
         if not 0 < num_transforms or not isinstance(num_transforms, int):
             message = (
-                'Number of transforms must be a natural number,'
-                f' not {num_transforms}'
+                'Number of transforms must be a strictly positive natural'
+                f'number, not {num_transforms}'
             )
             raise ValueError(message)
         self.num_transforms = num_transforms

--- a/torchio/transforms/augmentation/intensity/random_noise.py
+++ b/torchio/transforms/augmentation/intensity/random_noise.py
@@ -56,6 +56,6 @@ class RandomNoise(RandomTransform):
 
 
 def add_noise(tensor: torch.Tensor, mean: float, std: float) -> torch.Tensor:
-    noise = torch.FloatTensor(*tensor.shape).normal_(mean=mean, std=std)
+    noise = torch.randn(*tensor.shape) * std + mean
     tensor.data = tensor + noise
     return tensor

--- a/torchio/transforms/augmentation/intensity/random_swap.py
+++ b/torchio/transforms/augmentation/intensity/random_swap.py
@@ -27,7 +27,17 @@ class RandomSwap(RandomTransform):
             ):
         super().__init__(p=p, seed=seed)
         self.patch_size = to_tuple(patch_size)
-        self.num_iterations = num_iterations
+        self.num_iterations = self.parse_num_iterations(num_iterations)
+
+    @staticmethod
+    def parse_num_iterations(num_iterations):
+        if not isinstance(num_iterations, int):
+            raise TypeError('num_iterations must be an int,'
+                            f'not {num_iterations}')
+        if num_iterations < 0:
+            raise ValueError('num_iterations must be positive,'
+                             f'not {num_iterations}')
+        return num_iterations
 
     @staticmethod
     def get_params():

--- a/torchio/transforms/augmentation/random_transform.py
+++ b/torchio/transforms/augmentation/random_transform.py
@@ -2,14 +2,13 @@
 This is the docstring of random transform module
 """
 
-import numbers
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import torch
 import numpy as np
 
 from ...data.subject import Subject
-from ... import TypeNumber, TypeRangeFloat
+from ... import TypeRangeFloat
 from .. import Transform
 
 
@@ -31,46 +30,6 @@ class RandomTransform(Transform):
     def __call__(self, sample: Subject):
         self.check_seed()
         return super().__call__(sample)
-
-    @staticmethod
-    def parse_range(
-            nums_range: Union[TypeNumber, Tuple[TypeNumber, TypeNumber]],
-            name: str,
-            ) -> Tuple[TypeNumber, TypeNumber]:
-        r"""Adapted from ``torchvision.transforms.RandomRotation``.
-
-        Args:
-            nums_range: Tuple of two numbers :math:`(n_{min}, n_{max})`,
-                where :math:`n_{min} \leq n_{max}`.
-                If a single positive number :math:`n` is provided,
-                :math:`n_{min} = -n` and :math:`n_{max} = n`.
-            name: Name of the parameter, so that an informative error message
-                can be printed.
-
-        Returns:
-            A tuple of two numbers :math:`(n_{min}, n_{max})`.
-
-        Raises:
-            ValueError: if :attr:`nums_range` is negative
-            ValueError: if :math:`n_{max} \lt n_{min}`.
-        """
-        if isinstance(nums_range, numbers.Number):
-            if nums_range < 0:
-                raise ValueError(
-                    f'If {name} is a single number,'
-                    f' it must be positive, not {nums_range}')
-            return (-nums_range, nums_range)
-
-        if len(nums_range) != 2:
-            raise ValueError(
-                f'If {name} is a sequence,'
-                f' it must be of len 2, not {nums_range}')
-        min_degree, max_degree = nums_range
-        if min_degree > max_degree:
-            raise ValueError(
-                f'If {name} is a sequence, the second value must be'
-                f' equal or greater than the first, not {nums_range}')
-        return nums_range
 
     def parse_degrees(
             self,

--- a/torchio/transforms/augmentation/spatial/random_affine.py
+++ b/torchio/transforms/augmentation/spatial/random_affine.py
@@ -26,6 +26,8 @@ class RandomAffine(RandomTransform):
             For example, using ``scales=(0.5, 0.5)`` will zoom out the image,
             making the objects inside look twice as small while preserving
             the physical size and position of the image.
+            If only one value :math:`d` is provided,
+            :math:`\s_i \sim \mathcal{U}(0, d)`.
         degrees: Tuple :math:`(a, b)` defining the rotation range in degrees.
             The rotation angles around each axis are
             :math:`(\theta_1, \theta_2, \theta_3)`,
@@ -73,7 +75,7 @@ class RandomAffine(RandomTransform):
     """
     def __init__(
             self,
-            scales: Tuple[float, float] = (0.9, 1.1),
+            scales: TypeRangeFloat = (0.9, 1.1),
             degrees: TypeRangeFloat = 10,
             translation: TypeRangeFloat = 0,
             isotropic: bool = False,
@@ -84,7 +86,7 @@ class RandomAffine(RandomTransform):
             seed: Optional[int] = None,
             ):
         super().__init__(p=p, seed=seed)
-        self.scales = scales
+        self.scales = self.parse_range(scales, 'scales', min_constraint=0)
         self.degrees = self.parse_degrees(degrees)
         self.translation = self.parse_range(translation, 'translation')
         self.isotropic = isotropic

--- a/torchio/transforms/augmentation/spatial/random_downsample.py
+++ b/torchio/transforms/augmentation/spatial/random_downsample.py
@@ -25,8 +25,8 @@ class RandomDownsample(RandomTransform):
         >>> from torchio.datasets import Colin27
         >>> transform = RandomDownsample(axes=1, downsampling=2.)   # Multiply spacing of second axis by 2
         >>> transform = RandomDownsample(
-        >>>     axes=(0, 1, 2), downsampling=(2, 5)
-        >>> )   # Multiply spacing of one of the 3 axes by a factor randomly chosen in [2, 5]
+        ...     axes=(0, 1, 2), downsampling=(2, 5)
+        ... )   # Multiply spacing of one of the 3 axes by a factor randomly chosen in [2, 5]
         >>> colin = Colin27
         >>> transformed = transform(colin)  # images have now anisotropic spacing
     """

--- a/torchio/transforms/augmentation/spatial/random_downsample.py
+++ b/torchio/transforms/augmentation/spatial/random_downsample.py
@@ -1,6 +1,6 @@
 from typing import Union, Tuple, Optional, List
 import torch
-from ....torchio import DATA
+from ....torchio import TypeRangeFloat
 from ....data.subject import Subject
 from ....utils import to_tuple
 from .. import RandomTransform
@@ -19,18 +19,29 @@ class RandomDownsample(RandomTransform):
             :math:`(a, b)` is provided then :math:`m \sim \mathcal{U}(a, b)`.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+
+    Example:
+        >>> from torchio import RandomDownsample
+        >>> from torchio.datasets import Colin27
+        >>> transform = RandomDownsample(axes=1, downsampling=2.)   # Multiply spacing of second axis by 2
+        >>> transform = RandomDownsample(
+        >>>     axes=(0, 1, 2), downsampling=(2, 5)
+        >>> )   # Multiply spacing of one of the 3 axes by a factor randomly chosen in [2, 5]
+        >>> colin = Colin27
+        >>> transformed = transform(colin)  # images have now anisotropic spacing
     """
 
     def __init__(
             self,
             axes: Union[int, Tuple[int, ...]] = (0, 1, 2),
-            downsampling: float = (1.5, 5),
+            downsampling: TypeRangeFloat = (1.5, 5),
             p: float = 1,
             seed: Optional[int] = None,
             ):
         super().__init__(p=p, seed=seed)
         self.axes = self.parse_axes(axes)
-        self.downsampling_range = self.parse_downsampling(downsampling)
+        self.downsampling_range = self.parse_range(
+            downsampling, 'downsampling', min_constraint=1)
 
     @staticmethod
     def get_params(
@@ -40,19 +51,6 @@ class RandomDownsample(RandomTransform):
         axis = axes[torch.randint(0, len(axes), (1,))]
         downsampling = torch.FloatTensor(1).uniform_(*downsampling_range).item()
         return axis, downsampling
-
-    @staticmethod
-    def parse_downsampling(downsampling_factor):
-        try:
-            iter(downsampling_factor)
-        except TypeError:
-            downsampling_factor = downsampling_factor, downsampling_factor
-        for n in downsampling_factor:
-            if n <= 1:
-                message = (
-                    f'Downsampling factor must be a number > 1, not {n}')
-                raise ValueError(message)
-        return downsampling_factor
 
     @staticmethod
     def parse_axes(axes: Union[int, Tuple[int, ...]]):
@@ -66,7 +64,6 @@ class RandomDownsample(RandomTransform):
     def apply_transform(self, sample: Subject) -> Subject:
         axis, downsampling = self.get_params(self.axes, self.downsampling_range)
         random_parameters_dict = {'axis': axis, 'downsampling': downsampling}
-        items = sample.get_images_dict(intensity_only=False).items()
 
         target_spacing = list(sample.spacing)
         target_spacing[axis] *= downsampling


### PR DESCRIPTION
- Add tests (mainly about transforms)
- Refactor `RandomTransform.parse_range` to `Transform` and expand it to deal with ranges with specific constraints.
- Reinforce transform arguments' parsing
- Correct a problem with `Image` path handling (cropping an image without path was copying path `''` instead of `None`)
- Correct a problem with `RandomNoise` that made some tests failed in `test_transforms.py`
- Propose a minor change to `RandomSpike` (aims to be more intuitive: an `intensity` of `0` used to introduce an artifact while now an `intensity` of `0` does not produce any artifact)