### PR TITLE
Add support to take a dict as transform input

### DIFF
--- a/torchio/transforms/augmentation/intensity/random_bias_field.py
+++ b/torchio/transforms/augmentation/intensity/random_bias_field.py
@@ -1,5 +1,5 @@
 
-from typing import Union, Tuple, Optional
+from typing import Union, Tuple, Optional, List
 import numpy as np
 import torch
 from ....torchio import DATA, TypeData
@@ -29,6 +29,7 @@ class RandomBiasField(RandomTransform):
         order: Order of the basis polynomial functions.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
     """
     def __init__(
             self,
@@ -36,8 +37,9 @@ class RandomBiasField(RandomTransform):
             order: int = 3,
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self.coefficients_range = self.parse_range(
             coefficients, 'coefficients_range')
         self.order = self.parse_order(order)

--- a/torchio/transforms/augmentation/intensity/random_blur.py
+++ b/torchio/transforms/augmentation/intensity/random_blur.py
@@ -1,4 +1,4 @@
-from typing import Union, Tuple, Optional
+from typing import Union, Tuple, Optional, List
 import torch
 import numpy as np
 import SimpleITK as sitk
@@ -20,14 +20,16 @@ class RandomBlur(RandomTransform):
             :math:`\sigma_i \sim \mathcal{U}(0, d)`.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
     """
     def __init__(
             self,
             std: Union[float, Tuple[float, float]] = (0, 4),
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self.std_range = self.parse_range(std, 'std', min_constraint=0)
 
     def apply_transform(self, sample: Subject) -> dict:

--- a/torchio/transforms/augmentation/intensity/random_ghosting.py
+++ b/torchio/transforms/augmentation/intensity/random_ghosting.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional, Union
+from typing import Tuple, Optional, Union, List
 import torch
 import numpy as np
 from ....torchio import DATA
@@ -36,6 +36,7 @@ class RandomGhosting(RandomTransform):
             that generate the artifact.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     .. note:: The execution time of this transform does not depend on the
         number of ghosts.
@@ -48,8 +49,9 @@ class RandomGhosting(RandomTransform):
             restore: float = 0.02,
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         if not isinstance(axes, tuple):
             try:
                 axes = tuple(axes)

--- a/torchio/transforms/augmentation/intensity/random_labels_to_image.py
+++ b/torchio/transforms/augmentation/intensity/random_labels_to_image.py
@@ -1,5 +1,5 @@
 
-from typing import Union, Tuple, Optional, Dict, Sequence
+from typing import Union, Tuple, Optional, Dict, Sequence, List
 import torch
 import numpy as np
 from ....torchio import DATA, TypeData, TypeRangeFloat, TypeNumber, AFFINE
@@ -42,6 +42,7 @@ class RandomLabelsToImage(RandomTransform):
             :py:func:`torch.argmax()` on the channel dimension (i.e. 0).
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     .. note:: It is recommended to blur the new images to make the result more
         realistic. See
@@ -86,8 +87,9 @@ class RandomLabelsToImage(RandomTransform):
             discretize: bool = False,
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self.label_key, self.pv_label_keys = self.parse_keys(
             label_key, pv_label_keys)
         self.default_mean = self.parse_gaussian_parameter(default_mean, 'mean')

--- a/torchio/transforms/augmentation/intensity/random_motion.py
+++ b/torchio/transforms/augmentation/intensity/random_motion.py
@@ -46,6 +46,7 @@ class RandomMotion(RandomTransform):
         image_interpolation: See :ref:`Interpolation`.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     .. warning:: Large numbers of movements lead to longer execution times for
         3D images.
@@ -58,8 +59,9 @@ class RandomMotion(RandomTransform):
             image_interpolation: str = 'linear',
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self.degrees_range = self.parse_degrees(degrees)
         self.translation_range = self.parse_translation(translation)
         if not 0 < num_transforms or not isinstance(num_transforms, int):

--- a/torchio/transforms/augmentation/intensity/random_noise.py
+++ b/torchio/transforms/augmentation/intensity/random_noise.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional, Union
+from typing import Tuple, Optional, Union, List
 import torch
 from ....torchio import DATA
 from ....data.subject import Subject
@@ -25,6 +25,7 @@ class RandomNoise(RandomTransform):
             :math:`\sigma \sim \mathcal{U}(0, d)`.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
     """
     def __init__(
             self,
@@ -32,8 +33,9 @@ class RandomNoise(RandomTransform):
             std: Union[float, Tuple[float, float]] = (0, 0.25),
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self.mean_range = self.parse_range(mean, 'mean')
         self.std_range = self.parse_range(std, 'std', min_constraint=0)
 

--- a/torchio/transforms/augmentation/intensity/random_spike.py
+++ b/torchio/transforms/augmentation/intensity/random_spike.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional, Union
+from typing import Tuple, Optional, Union, List
 import torch
 import numpy as np
 import SimpleITK as sitk
@@ -31,6 +31,7 @@ class RandomSpike(RandomTransform):
             Larger values generate more distorted images.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     .. note:: The execution time of this transform does not depend on the
         number of spikes.
@@ -41,8 +42,9 @@ class RandomSpike(RandomTransform):
             intensity: Union[float, Tuple[float, float]] = (1, 3),
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self.intensity_range = self.parse_range(
             intensity, 'intensity_range')
         self.num_spikes_range = self.parse_range(

--- a/torchio/transforms/augmentation/intensity/random_swap.py
+++ b/torchio/transforms/augmentation/intensity/random_swap.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, List
 import torch
 import numpy as np
 from ....data.subject import Subject
@@ -20,6 +20,7 @@ class RandomSwap(RandomTransform):
         num_iterations: Number of times that two patches will be swapped.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
     """
     def __init__(
             self,
@@ -27,8 +28,9 @@ class RandomSwap(RandomTransform):
             num_iterations: int = 100,
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self.patch_size = to_tuple(patch_size)
         self.num_iterations = self.parse_num_iterations(num_iterations)
 

--- a/torchio/transforms/augmentation/random_transform.py
+++ b/torchio/transforms/augmentation/random_transform.py
@@ -2,7 +2,7 @@
 This is the docstring of random transform module
 """
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 import torch
 import numpy as np
@@ -18,13 +18,15 @@ class RandomTransform(Transform):
     Args:
         p: Probability that this transform will be applied.
         seed: Seed for :py:mod:`torch` random number generator.
+        keys: See :py:class:`~torchio.transforms.Transform`.
     """
     def __init__(
             self,
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p)
+        super().__init__(p=p, keys=keys)
         self._seed = seed
 
     def __call__(self, sample: Subject):

--- a/torchio/transforms/augmentation/spatial/random_affine.py
+++ b/torchio/transforms/augmentation/spatial/random_affine.py
@@ -56,6 +56,7 @@ class RandomAffine(RandomTransform):
         image_interpolation: See :ref:`Interpolation`.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     Example:
         >>> import torchio
@@ -85,8 +86,9 @@ class RandomAffine(RandomTransform):
             image_interpolation: str = 'linear',
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self.scales = self.parse_range(scales, 'scales', min_constraint=0)
         self.degrees = self.parse_degrees(degrees)
         self.translation = self.parse_range(translation, 'translation')

--- a/torchio/transforms/augmentation/spatial/random_downsample.py
+++ b/torchio/transforms/augmentation/spatial/random_downsample.py
@@ -19,6 +19,7 @@ class RandomDownsample(RandomTransform):
             :math:`(a, b)` is provided then :math:`m \sim \mathcal{U}(a, b)`.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     Example:
         >>> from torchio import RandomDownsample
@@ -37,8 +38,9 @@ class RandomDownsample(RandomTransform):
             downsampling: TypeRangeFloat = (1.5, 5),
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self.axes = self.parse_axes(axes)
         self.downsampling_range = self.parse_range(
             downsampling, 'downsampling', min_constraint=1)
@@ -70,7 +72,6 @@ class RandomDownsample(RandomTransform):
         transform = Resample(
             tuple(target_spacing),
             image_interpolation='nearest',
-            copy=False,  # already copied in super().__init__
         )
         sample = transform(sample)
         sample.add_transform(self, random_parameters_dict)

--- a/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
+++ b/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
@@ -1,6 +1,6 @@
 import warnings
 from numbers import Number
-from typing import Tuple, Optional, Union
+from typing import Tuple, Optional, Union, List
 import torch
 import numpy as np
 import SimpleITK as sitk
@@ -54,6 +54,7 @@ class RandomElasticDeformation(RandomTransform):
             points of the coarse grid.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     `This gist <https://gist.github.com/fepegar/b723d15de620cd2a3a4dbd71e491b59d>`_
     can also be used to better understand the meaning of the parameters.
@@ -115,8 +116,9 @@ class RandomElasticDeformation(RandomTransform):
             image_interpolation: str = 'linear',
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self._bspline_transformation = None
         self.num_control_points = to_tuple(num_control_points, length=3)
         self.parse_control_points(self.num_control_points)

--- a/torchio/transforms/augmentation/spatial/random_flip.py
+++ b/torchio/transforms/augmentation/spatial/random_flip.py
@@ -16,6 +16,7 @@ class RandomFlip(RandomTransform):
             computed on a per-axis basis.
         p: Probability that this transform will be applied.
         seed: See :py:class:`~torchio.transforms.augmentation.RandomTransform`.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     .. note:: If the input image is 2D, all axes should be in ``(0, 1)``.
     """
@@ -26,8 +27,9 @@ class RandomFlip(RandomTransform):
             flip_probability: float = 0.5,
             p: float = 1,
             seed: Optional[int] = None,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, seed=seed)
+        super().__init__(p=p, seed=seed, keys=keys)
         self.axes = self.parse_axes(axes)
         self.flip_probability = self.parse_probability(
             flip_probability,

--- a/torchio/transforms/lambda_transform.py
+++ b/torchio/transforms/lambda_transform.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Optional
+from typing import Sequence, Optional, List
 import torch
 from ..data.subject import Subject
 from ..torchio import DATA, TYPE, TypeCallable
@@ -15,6 +15,7 @@ class Lambda(Transform):
             which this transform should be applied. If ``None``, the transform
             will be applied to all images in the sample.
         p: Probability that this transform will be applied.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     Example:
         >>> import torchio
@@ -30,8 +31,9 @@ class Lambda(Transform):
             function: TypeCallable,
             types_to_apply: Optional[Sequence[str]] = None,
             p: float = 1,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p)
+        super().__init__(p=p, keys=keys)
         self.function = function
         self.types_to_apply = types_to_apply
 

--- a/torchio/transforms/preprocessing/intensity/normalization_transform.py
+++ b/torchio/transforms/preprocessing/intensity/normalization_transform.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, List, Optional
 import torch
 from ....data.subject import Subject
 from ....torchio import DATA, TypeCallable
@@ -19,6 +19,7 @@ class NormalizationTransform(Transform):
             - A string: the mask image is retrieved from the sample, which is expected the string as a key
 
             - A function: the mask image is computed as a function of the intensity image. The function must receive and return a :py:class:`torch.Tensor`
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     Example:
         >>> import torchio
@@ -38,6 +39,7 @@ class NormalizationTransform(Transform):
             self,
             masking_method: TypeMaskingMethod = None,
             p: float = 1,
+            keys: Optional[List[str]] = None,
             ):
         """
         masking_method is used to choose the values used for normalization.
@@ -46,7 +48,7 @@ class NormalizationTransform(Transform):
          - A function: the mask will be computed using the function
          - None: all values are used
         """
-        super().__init__(p=p)
+        super().__init__(p=p, keys=keys)
         self.mask_name = None
         if masking_method is None:
             self.masking_method = self.ones

--- a/torchio/transforms/preprocessing/intensity/rescale.py
+++ b/torchio/transforms/preprocessing/intensity/rescale.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Optional, List
 
 import torch
 import numpy as np
@@ -25,6 +26,7 @@ class RescaleIntensity(NormalizationTransform):
         masking_method: See
             :py:class:`~torchio.transforms.preprocessing.normalization_transform.NormalizationTransform`.
         p: Probability that this transform will be applied.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     .. _this scikit-image example: https://scikit-image.org/docs/dev/auto_examples/color_exposure/plot_equalize.html#sphx-glr-auto-examples-color-exposure-plot-equalize-py
     .. _nn-UNet paper: https://arxiv.org/abs/1809.10486
@@ -35,8 +37,9 @@ class RescaleIntensity(NormalizationTransform):
             percentiles: TypeRangeFloat = (0, 100),
             masking_method: TypeMaskingMethod = None,
             p: float = 1,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(masking_method=masking_method, p=p)
+        super().__init__(masking_method=masking_method, p=p, keys=keys)
         self.out_min, self.out_max = self.parse_range(
             out_min_max, 'out_min_max')
         self.percentiles = self.parse_range(

--- a/torchio/transforms/preprocessing/intensity/z_normalization.py
+++ b/torchio/transforms/preprocessing/intensity/z_normalization.py
@@ -1,4 +1,5 @@
 import torch
+from typing import Optional, List
 from ....data.subject import Subject
 from ....torchio import DATA
 from .normalization_transform import NormalizationTransform, TypeMaskingMethod
@@ -11,13 +12,15 @@ class ZNormalization(NormalizationTransform):
         masking_method: See
             :py:class:`~torchio.transforms.preprocessing.normalization_transform.NormalizationTransform`.
         p: Probability that this transform will be applied.
+        keys: See :py:class:`~torchio.transforms.Transform`.
     """
     def __init__(
             self,
             masking_method: TypeMaskingMethod = None,
             p: float = 1,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(masking_method=masking_method, p=p)
+        super().__init__(masking_method=masking_method, p=p, keys=keys)
 
     def apply_normalization(
             self,

--- a/torchio/transforms/preprocessing/spatial/bounds_transform.py
+++ b/torchio/transforms/preprocessing/spatial/bounds_transform.py
@@ -1,4 +1,4 @@
-from typing import Union, Tuple
+from typing import Union, Tuple, List, Optional
 import torch
 import numpy as np
 import SimpleITK as sitk
@@ -22,10 +22,15 @@ class BoundsTransform(Transform):
         bounds_parameters: The meaning of this argument varies according to the
             child class.
         p: Probability that this transform will be applied.
-
+        keys: See :py:class:`~torchio.transforms.Transform`.
     """
-    def __init__(self, bounds_parameters: TypeBounds, p: float = 1):
-        super().__init__(p=p)
+    def __init__(
+            self,
+            bounds_parameters: TypeBounds,
+            p: float = 1,
+            keys: Optional[List[str]] = None,
+            ):
+        super().__init__(p=p, keys=keys)
         self.bounds_parameters = self.parse_bounds(bounds_parameters)
 
     @property

--- a/torchio/transforms/preprocessing/spatial/crop_or_pad.py
+++ b/torchio/transforms/preprocessing/spatial/crop_or_pad.py
@@ -1,7 +1,9 @@
 import warnings
-from typing import Union, Tuple, Optional
+from typing import Union, Tuple, Optional, List
+
 import numpy as np
 from deprecated import deprecated
+
 from .pad import Pad
 from .crop import Crop
 from .bounds_transform import BoundsTransform, TypeTripletInt, TypeSixBounds
@@ -26,6 +28,7 @@ class CropOrPad(BoundsTransform):
             of the bounding box of non-zero values in the image named
             :py:attr:`mask_name`.
         p: Probability that this transform will be applied.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     Example:
         >>> import torchio
@@ -50,8 +53,9 @@ class CropOrPad(BoundsTransform):
             padding_mode: Union[str, float] = 0,
             mask_name: Optional[str] = None,
             p: float = 1,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(target_shape, p=p)
+        super().__init__(target_shape, p=p, keys=keys)
         self.padding_mode = padding_mode
         if mask_name is not None and not isinstance(mask_name, str):
             message = (

--- a/torchio/transforms/preprocessing/spatial/pad.py
+++ b/torchio/transforms/preprocessing/spatial/pad.py
@@ -1,5 +1,5 @@
 from numbers import Number
-from typing import Callable, Union
+from typing import Callable, Union, List, Optional
 import SimpleITK as sitk
 from .bounds_transform import BoundsTransform, TypeBounds
 
@@ -38,6 +38,7 @@ class Pad(BoundsTransform):
             - ``wrap`` Same as ``circular``.
 
         p: Probability that this transform will be applied.
+        keys: See :py:class:`~torchio.transforms.Transform`.
     """
 
     PADDING_FUNCTIONS = {
@@ -54,13 +55,14 @@ class Pad(BoundsTransform):
             padding: TypeBounds,
             padding_mode: Union[str, float] = 0,
             p: float = 1,
+            keys: Optional[List[str]] = None,
             ):
         """
         padding_mode can be 'constant', 'reflect', 'replicate' or 'circular'.
         See https://pytorch.org/docs/stable/nn.functional.html#pad for more
         information about this transform.
         """
-        super().__init__(padding, p=p)
+        super().__init__(padding, p=p, keys=keys)
         self.padding_mode, self.fill = self.parse_padding_mode(padding_mode)
 
     @classmethod

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from numbers import Number
-from typing import Union, Tuple, Optional
+from typing import Union, Tuple, Optional, List
 
 import torch
 import numpy as np
@@ -41,6 +41,7 @@ class Resample(Transform):
             supported for backward compatibility,
             but will be removed in a future version.
         p: Probability that this transform will be applied.
+        keys: See :py:class:`~torchio.transforms.Transform`.
 
     .. note:: Resampling is performed using
         :py:meth:`nibabel.processing.resample_to_output` or
@@ -66,9 +67,9 @@ class Resample(Transform):
             image_interpolation: str = 'linear',
             pre_affine_name: Optional[str] = None,
             p: float = 1,
-            copy: bool = True,
+            keys: Optional[List[str]] = None,
             ):
-        super().__init__(p=p, copy=copy)
+        super().__init__(p=p, keys=keys)
         self.reference_image, self.target_spacing = self.parse_target(target)
         self.interpolation_order = self.parse_interpolation(image_interpolation)
         self.affine_name = pre_affine_name


### PR DESCRIPTION
This should make integration with MONAI and Eisen easier, as both
libraries use plain dictionaries to represent data.

This is supported for most of the transforms. The behavior of `Lambda`,
`ToCanonical` or `HistogramStandardization` needs to be checked.

Related to #221.