### PR TITLE
Enable to give Image channels as different files

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -18,7 +18,7 @@ class TestImage(TorchioTestCase):
             ScalarImage('nopath')
 
     def test_wrong_path_value(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(RuntimeError):
             ScalarImage('~&./@#"!?X7=+')
 
     def test_wrong_path_type(self):

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -5,7 +5,7 @@
 import copy
 import torch
 import numpy as np
-from torchio import Image, ScalarImage, LabelMap, Subject, INTENSITY, LABEL
+from torchio import ScalarImage, LabelMap, Subject, INTENSITY, LABEL, STEM
 from ..utils import TorchioTestCase
 from torchio import RandomFlip, RandomAffine
 
@@ -117,3 +117,33 @@ class TestImage(TorchioTestCase):
         lps = image.get_center(lps=True)
         self.assertEqual(ras, (1, 1, 1))
         self.assertEqual(lps, (-1, -1, 1))
+
+    def test_with_a_list_of_paths(self):
+        shape = (5, 5, 5)
+        path1 = self.get_image_path('path1', shape=shape)
+        path2 = self.get_image_path('path2', shape=shape)
+        image = ScalarImage(path=[path1, path2])
+        self.assertEqual(image.shape, (2, 5, 5, 5))
+        self.assertEqual(image[STEM], ['path1', 'path2'])
+
+    def test_with_a_list_of_images_with_different_shapes(self):
+        path1 = self.get_image_path('path1', shape=(5, 5, 5))
+        path2 = self.get_image_path('path2', shape=(7, 5, 5))
+        image = ScalarImage(path=[path1, path2])
+        with self.assertRaises(RuntimeError):
+            image._load()
+
+    def test_with_a_list_of_images_with_different_affines(self):
+        path1 = self.get_image_path('path1', spacing=(1, 1, 1))
+        path2 = self.get_image_path('path2', spacing=(1, 2, 1))
+        image = ScalarImage(path=[path1, path2])
+        with self.assertWarns(RuntimeWarning):
+            image._load()
+
+    def test_with_a_list_of_2d_paths(self):
+        shape = (5, 5)
+        path1 = self.get_image_path('path1', shape=shape)
+        path2 = self.get_image_path('path2', shape=shape)
+        image = ScalarImage(path=[path1, path2])
+        self.assertEqual(image.shape, (2, 1, 5, 5))
+        self.assertEqual(image[STEM], ['path1', 'path2'])

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -17,6 +17,10 @@ class TestImage(TorchioTestCase):
         with self.assertRaises(FileNotFoundError):
             ScalarImage('nopath')
 
+    def test_wrong_path_value(self):
+        with self.assertRaises(TypeError):
+            ScalarImage('~&./@#"!?X7=+')
+
     def test_wrong_path_type(self):
         with self.assertRaises(TypeError):
             ScalarImage(5)
@@ -117,6 +121,10 @@ class TestImage(TorchioTestCase):
         lps = image.get_center(lps=True)
         self.assertEqual(ras, (1, 1, 1))
         self.assertEqual(lps, (-1, -1, 1))
+
+    def test_with_list_of_missing_files(self):
+        with self.assertRaises(FileNotFoundError):
+            ScalarImage(path=['nopath', 'error'])
 
     def test_with_a_list_of_paths(self):
         shape = (5, 5, 5)

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -1,6 +1,6 @@
 import warnings
 from pathlib import Path
-from typing import Any, Dict, Tuple, Optional
+from typing import Any, Dict, Tuple, Optional, Union, Sequence, List
 
 import torch
 import humanize
@@ -41,12 +41,14 @@ class Image(dict):
     `SimpleITK docs`_.
 
     Args:
-        path: Path to a file that can be read by
+        path: Path to a file or sequence of paths to files that can be read by
             :mod:`SimpleITK` or :mod:`nibabel`, or to a directory containing
             DICOM files. If :py:attr:`tensor` is given, the data in
             :py:attr:`path` will not be read. The data is expected to be 2D or
             3D, and may have multiple channels (see :attr:`num_spatial_dims` and
-            :attr:`channels_last`).
+            :attr:`channels_last`). If a sequence of paths is given, data
+            will be concatenated on the channel dimension so spatial
+            dimensions must match.
         type: Type of image, such as :attr:`torchio.INTENSITY` or
             :attr:`torchio.LABEL`. This will be used by the transforms to
             decide whether to apply an operation, or which interpolation to use
@@ -124,7 +126,7 @@ class Image(dict):
     """
     def __init__(
             self,
-            path: Optional[TypePath] = None,
+            path: Union[TypePath, Sequence[TypePath]] = None,
             type: str = None,
             tensor: Optional[TypeData] = None,
             affine: Optional[TypeData] = None,
@@ -262,16 +264,35 @@ class Image(dict):
         return bounds_x, bounds_y, bounds_z
 
     @staticmethod
-    def _parse_path(path: TypePath) -> Path:
+    def _parse_path(
+            path: Union[TypePath, Sequence[TypePath]]
+            ) -> Union[Path, List[str]]:
         if path is None:
             return None
-        try:
-            path = Path(path).expanduser()
-        except TypeError:
-            message = f'Conversion to path not possible for variable: {path}'
-            raise TypeError(message)
-        if not (path.is_file() or path.is_dir()):  # might be a dir with DICOM
-            raise FileNotFoundError(f'File not found: {path}')
+
+        if isinstance(path, (str, Path)):
+            try:
+                path = Path(path).expanduser()
+            except TypeError:
+                message = f'Conversion to path not possible for variable: ' \
+                          f'{path}'
+                raise TypeError(message)
+        else:
+            try:
+                path = [Path(p).expanduser() for p in path]
+            except TypeError:
+                message = f'Conversion to list of paths not possible for ' \
+                          f'variable: {path}'
+                raise TypeError(message)
+
+        if isinstance(path, Path):
+            if not (path.is_file() or path.is_dir()):   # might be a DICOM dir
+                raise FileNotFoundError(f'File not found: {path}')
+        else:
+            for p in path:
+                if not (p.is_file() or p.is_dir()):  # might be a DICOM dir
+                    raise FileNotFoundError(f'File not found: {p}')
+            path = [str(p) for p in path]   # To match path representation
         return path
 
     def parse_tensor(self, tensor: TypeData) -> torch.Tensor:
@@ -299,7 +320,7 @@ class Image(dict):
             raise ValueError(f'Affine shape must be (4, 4), not {affine.shape}')
         return affine
 
-    def _load(self) -> Tuple[torch.Tensor, np.ndarray]:
+    def _load(self) -> None:
         r"""Load the image from disk.
 
         Returns:
@@ -309,11 +330,35 @@ class Image(dict):
         """
         if self._loaded:
             return
-        tensor, affine = read_image(self.path)
+
+        paths = self.path if isinstance(self.path, list) else [self.path]
+        tensor, affine = read_image(paths[0])
         tensor = self.parse_tensor_shape(tensor)
 
         if self.check_nans and torch.isnan(tensor).any():
-            warnings.warn(f'NaNs found in file "{self.path}"')
+            warnings.warn(f'NaNs found in file "{paths[0]}"')
+
+        tensors = [tensor]
+        for path in paths[1:]:
+            new_tensor, new_affine = read_image(path)
+            new_tensor = self.parse_tensor_shape(new_tensor)
+
+            if self.check_nans and torch.isnan(tensor).any():
+                warnings.warn(f'NaNs found in file "{path}"')
+
+            if not np.array_equal(affine, new_affine):
+                message = 'Files have different affine matrices'
+                warnings.warn(message, RuntimeWarning)
+
+            if not tensor.shape[1:] == new_tensor.shape[1:]:
+                message = f'Files shape do not match, found {tensor.shape}' \
+                          f'and {new_tensor.shape}'
+                RuntimeError(message)
+
+            tensors.append(new_tensor)
+
+        tensor = torch.cat(tensors, dim=0)
+
         self[DATA] = tensor
         self[AFFINE] = affine
         self._loaded = True

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -126,7 +126,7 @@ class Image(dict):
     """
     def __init__(
             self,
-            path: Union[TypePath, Sequence[TypePath]] = None,
+            path: Union[TypePath, Sequence[TypePath], None] = None,
             type: str = None,
             tensor: Optional[TypeData] = None,
             affine: Optional[TypeData] = None,
@@ -273,16 +273,19 @@ class Image(dict):
         if isinstance(path, (str, Path)):
             try:
                 path = Path(path).expanduser()
-            except TypeError:
-                message = f'Conversion to path not possible for variable: ' \
-                          f'{path}'
+            except (TypeError, RuntimeError):
+                message = (
+                    f'Conversion to path not possible for variable: {path}'
+                )
                 raise TypeError(message)
         else:
             try:
                 path = [Path(p).expanduser() for p in path]
-            except TypeError:
-                message = f'Conversion to list of paths not possible for ' \
-                          f'variable: {path}'
+            except (TypeError, RuntimeError):
+                message = (
+                    'Conversion to list of paths not possible for '
+                    f'variable: {path}'
+                )
                 raise TypeError(message)
 
         if isinstance(path, Path):
@@ -351,8 +354,10 @@ class Image(dict):
                 warnings.warn(message, RuntimeWarning)
 
             if not tensor.shape[1:] == new_tensor.shape[1:]:
-                message = f'Files shape do not match, found {tensor.shape}' \
-                          f'and {new_tensor.shape}'
+                message = (
+                    f'Files shape do not match, found {tensor.shape}'
+                    f'and {new_tensor.shape}'
+                )
                 RuntimeError(message)
 
             tensors.append(new_tensor)

--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -43,12 +43,16 @@ def to_tuple(
     return value
 
 
-def get_stem(path: TypePath) -> str:
+def get_stem(
+        path: Union[TypePath, List[TypePath]]
+        ) -> Union[str, List[str]]:
     """
     '/home/user/image.nii.gz' -> 'image'
     """
-    path = Path(path)
-    return path.name.split('.')[0]
+    if isinstance(path, (str, Path)):
+        path = Path(path)
+        return path.name.split('.')[0]
+    return [Path(p).name.split('.')[0] for p in path]
 
 
 def create_dummy_dataset(

--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -49,10 +49,11 @@ def get_stem(
     """
     '/home/user/image.nii.gz' -> 'image'
     """
+    def _get_stem(path_string):
+        return Path(path_string).name.split('.')[0]
     if isinstance(path, (str, Path)):
-        path = Path(path)
-        return path.name.split('.')[0]
-    return [Path(p).name.split('.')[0] for p in path]
+        return _get_stem(path)
+    return [_get_stem(p) for p in path]
 
 
 def create_dummy_dataset(


### PR DESCRIPTION
Make `Image` accept a sequence of paths and concatenate loaded tensors on the channel dimension. See https://github.com/fepegar/torchio/issues/253#issuecomment-669793181.