### PR TITLE
Refactor RandomLabelsToImage

### DIFF
--- a/tests/transforms/augmentation/test_random_labels_to_image.py
+++ b/tests/transforms/augmentation/test_random_labels_to_image.py
@@ -8,11 +8,11 @@ from numpy.testing import assert_array_equal
 class TestRandomLabelsToImage(TorchioTestCase):
     """Tests for `RandomLabelsToImage`."""
     def test_random_simulation(self):
-        """The transform runs without error and an 'image' key is
+        """The transform runs without error and an 'image_from_labels' key is
         present in the transformed sample."""
         transform = RandomLabelsToImage(label_key='label')
         transformed = transform(self.sample)
-        self.assertIn('image', transformed)
+        self.assertIn('image_from_labels', transformed)
 
     def test_deterministic_simulation(self):
         """The transform creates an image where values are equal to given
@@ -25,11 +25,11 @@ class TestRandomLabelsToImage(TorchioTestCase):
         )
         transformed = transform(self.sample)
         assert_array_equal(
-            transformed['image'][DATA] == 0.5,
+            transformed['image_from_labels'][DATA] == 0.5,
             self.sample['label'][DATA] == 0
         )
         assert_array_equal(
-            transformed['image'][DATA] == 2,
+            transformed['image_from_labels'][DATA] == 2,
             self.sample['label'][DATA] == 1
         )
 
@@ -45,11 +45,11 @@ class TestRandomLabelsToImage(TorchioTestCase):
         )
         transformed = transform(self.sample)
         assert_array_equal(
-            transformed['image'][DATA] == 0.5,
+            transformed['image_from_labels'][DATA] == 0.5,
             self.sample['label'][DATA] == 0
         )
         assert_array_equal(
-            transformed['image'][DATA] == 2,
+            transformed['image_from_labels'][DATA] == 2,
             self.sample['label'][DATA] == 1
         )
 
@@ -64,10 +64,13 @@ class TestRandomLabelsToImage(TorchioTestCase):
         )
         transformed = transform(sample)
         assert_array_equal(
-            transformed['image'][DATA][0],
+            transformed['image_from_labels'][DATA][0],
             sample['label'][DATA][0] * 0.5 + sample['label'][DATA][1] * 1
         )
-        self.assertEqual(transformed['image'][DATA].shape, (1, 10, 20, 30))
+        self.assertEqual(
+            transformed['image_from_labels'][DATA].shape,
+            (1, 10, 20, 30)
+        )
 
     def test_deterministic_simulation_with_discretized_pv_map(self):
         """The transform creates an image where values are equal to given mean
@@ -82,7 +85,7 @@ class TestRandomLabelsToImage(TorchioTestCase):
         )
         transformed = transform(sample)
         assert_array_equal(
-            transformed['image'][DATA],
+            transformed['image_from_labels'][DATA],
             (sample['label'][DATA] > 0) * 0.5
         )
 

--- a/tests/transforms/augmentation/test_random_labels_to_image.py
+++ b/tests/transforms/augmentation/test_random_labels_to_image.py
@@ -1,5 +1,6 @@
+import numpy as np
 from torchio.transforms import RandomLabelsToImage
-from torchio import DATA, AFFINE
+from torchio import DATA
 from ...utils import TorchioTestCase
 from numpy.testing import assert_array_equal
 
@@ -19,41 +20,70 @@ class TestRandomLabelsToImage(TorchioTestCase):
         Using a label map."""
         transform = RandomLabelsToImage(
             label_key='label',
-            gaussian_parameters={1: {'mean': 0.5, 'std': 0}}
+            mean=[0.5, 2],
+            std=[0, 0]
         )
         transformed = transform(self.sample)
         assert_array_equal(
             transformed['image'][DATA] == 0.5,
-            self.sample['label'][DATA] == 1
+            self.sample['label'][DATA] == 0
         )
-
-    def test_deterministic_simulation_with_pv_label_map(self):
-        """The transform creates an image where values are equal to given mean
-        if standard deviation is zero.
-        Using a PV label map."""
-        transform = RandomLabelsToImage(
-            pv_label_keys=['label'],
-            gaussian_parameters={'label': {'mean': 0.5, 'std': 0}}
-        )
-        transformed = transform(self.sample)
         assert_array_equal(
-            transformed['image'][DATA] == 0.5,
+            transformed['image'][DATA] == 2,
             self.sample['label'][DATA] == 1
         )
 
-    def test_deterministic_simulation_with_binary_pv_label_map(self):
+    def test_deterministic_simulation_with_discretized_label_map(self):
         """The transform creates an image where values are equal to given mean
         if standard deviation is zero.
-        Using a discretized PV label map."""
+        Using a discretized label map."""
         transform = RandomLabelsToImage(
-            pv_label_keys=['label'],
-            gaussian_parameters={'label': {'mean': 0.5, 'std': 0}},
+            label_key='label',
+            mean=[0.5, 2],
+            std=[0, 0],
             discretize=True
         )
         transformed = transform(self.sample)
         assert_array_equal(
             transformed['image'][DATA] == 0.5,
+            self.sample['label'][DATA] == 0
+        )
+        assert_array_equal(
+            transformed['image'][DATA] == 2,
             self.sample['label'][DATA] == 1
+        )
+
+    def test_deterministic_simulation_with_pv_map(self):
+        """The transform creates an image where values are equal to given
+        mean weighted by partial-volume if standard deviation is zero."""
+        sample = self.get_sample_with_partial_volume_label_map(components=2)
+        transform = RandomLabelsToImage(
+            label_key='label',
+            mean=[0.5, 1],
+            std=[0, 0]
+        )
+        transformed = transform(sample)
+        assert_array_equal(
+            transformed['image'][DATA][0],
+            sample['label'][DATA][0] * 0.5 + sample['label'][DATA][1] * 1
+        )
+        self.assertEqual(transformed['image'][DATA].shape, (1, 10, 20, 30))
+
+    def test_deterministic_simulation_with_discretized_pv_map(self):
+        """The transform creates an image where values are equal to given mean
+        if standard deviation is zero.
+        Using a discretized partial-volume label map."""
+        sample = self.get_sample_with_partial_volume_label_map()
+        transform = RandomLabelsToImage(
+            label_key='label',
+            mean=[0.5],
+            std=[0],
+            discretize=True
+        )
+        transformed = transform(sample)
+        assert_array_equal(
+            transformed['image'][DATA],
+            (sample['label'][DATA] > 0) * 0.5
         )
 
     def test_filling(self):
@@ -63,7 +93,7 @@ class TestRandomLabelsToImage(TorchioTestCase):
         transform = RandomLabelsToImage(
             label_key='label',
             image_key='t1',
-            gaussian_parameters={0: {'mean': 0.0, 'std': 0}}
+            used_labels=[1]
         )
         t1_indices = self.sample['label'][DATA] == 0
         transformed = transform(self.sample)
@@ -72,48 +102,57 @@ class TestRandomLabelsToImage(TorchioTestCase):
             self.sample['t1'][DATA][t1_indices]
         )
 
-    def test_filling_with_pv_label_map(self):
+    def test_filling_with_discretized_label_map(self):
         """The transform can fill in the generated image with an already
         existing image.
-        Using a PV label map."""
+        Using a discretized label map."""
         transform = RandomLabelsToImage(
-            pv_label_keys=['label'],
-            image_key='t1'
-        )
-        t1_indices = self.sample['label'][DATA] == 0
-        transformed = transform(self.sample)
-        assert_array_equal(
-            transformed['t1'][DATA][t1_indices],
-            self.sample['t1'][DATA][t1_indices]
-        )
-
-    def test_filling_with_binary_pv_label_map(self):
-        """The transform can fill in the generated image with an already
-        existing image.
-        Using a discretized PV label map."""
-        transform = RandomLabelsToImage(
-            pv_label_keys=['label'],
+            label_key='label',
             image_key='t1',
-            discretize=True
+            discretize=True,
+            used_labels=[1]
         )
-        t1_indices = self.sample['label'][DATA] == 0
+        t1_indices = self.sample['label'][DATA] < 0.5
         transformed = transform(self.sample)
         assert_array_equal(
             transformed['t1'][DATA][t1_indices],
             self.sample['t1'][DATA][t1_indices]
         )
 
-    def test_missing_label_key_and_pv_label_keys(self):
-        """The transform raises an error if both label_key and pv_label_keys
-         are None."""
-        with self.assertRaises(ValueError):
-            RandomLabelsToImage()
+    def test_filling_with_discretized_pv_label_map(self):
+        """The transform can fill in the generated image with an already
+        existing image.
+        Using a discretized partial-volume label map."""
+        sample = self.get_sample_with_partial_volume_label_map(components=2)
+        transform = RandomLabelsToImage(
+            label_key='label',
+            image_key='t1',
+            discretize=True,
+            used_labels=[1]
+        )
+        t1_indices = sample['label'][DATA].argmax(dim=0) == 0
+        transformed = transform(sample)
+        assert_array_equal(
+            transformed['t1'][DATA][0][t1_indices],
+            sample['t1'][DATA][0][t1_indices]
+        )
 
-    def test_with_both_label_key_and_pv_label_keys(self):
-        """The transform raises an error if both label_key and pv_label_keys
-        are set."""
-        with self.assertRaises(ValueError):
-            RandomLabelsToImage(label_key='label', pv_label_keys=['label'])
+    def test_filling_without_any_hole(self):
+        """The transform does not fill anything if there is no hole."""
+        transform = RandomLabelsToImage(
+            label_key='label',
+            image_key='t1',
+            default_std=0.,
+            default_mean=-1.
+        )
+        original_t1 = self.sample.t1.data.clone()
+        transformed = transform(self.sample)
+        assert np.not_equal(original_t1, transformed.t1.data).all()
+
+    def test_missing_label_key(self):
+        """The transform raises an error if no label_key is given."""
+        with self.assertRaises(TypeError):
+            RandomLabelsToImage()
 
     def test_with_bad_default_mean_range(self):
         """The transform raises an error if default_mean is not a
@@ -143,37 +182,67 @@ class TestRandomLabelsToImage(TorchioTestCase):
         with self.assertRaises(TypeError):
             RandomLabelsToImage(label_key=42)
 
-    def test_with_wrong_pv_label_keys_type(self):
+    def test_with_wrong_used_labels_type(self):
         """The transform raises an error if a wrong type is given for
-        pv_label_keys."""
+        used_labels."""
         with self.assertRaises(TypeError):
-            RandomLabelsToImage(pv_label_keys=42)
+            RandomLabelsToImage(label_key='label', used_labels=42)
 
-    def test_with_wrong_pv_label_keys_elements_type(self):
+    def test_with_wrong_used_labels_elements_type(self):
         """The transform raises an error if wrong type are given for
-        pv_label_keys elements."""
+        used_labels elements."""
+        with self.assertRaises(ValueError):
+            RandomLabelsToImage(label_key='label', used_labels=['wrong'])
+
+    def test_with_wrong_mean_type(self):
+        """The transform raises an error if wrong type is given for mean."""
         with self.assertRaises(TypeError):
-            RandomLabelsToImage(pv_label_keys=[42, 27])
+            RandomLabelsToImage(label_key='label', mean=42)
 
-    def test_with_inconsistent_pv_label_maps_shapes(self):
-        """The transform raises an error if PV label maps have
-        inconsistent shapes."""
-        transform = RandomLabelsToImage(
-            pv_label_keys=['label', 'label2'],
-        )
-        sample = self.get_inconsistent_sample()
-        with self.assertRaises(RuntimeError):
-            transform(sample)
+    def test_with_wrong_mean_elements_type(self):
+        """The transform raises an error if wrong type are given for
+        mean elements."""
+        with self.assertRaises(ValueError):
+            RandomLabelsToImage(label_key='label', mean=['wrong'])
 
-    def test_with_inconsistent_pv_label_maps_affines(self):
-        """The transform raises a warning if PV label maps have
-        inconsistent affines."""
-        transform = RandomLabelsToImage(
-            pv_label_keys=['label', 'label2'],
-        )
-        sample = self.get_inconsistent_sample()
-        sample.load()  # otherwise sample['label2'] data wil be loaded later
-        sample['label2'][DATA] = sample['label'][DATA].clone()
-        sample['label2'][AFFINE][0, 0] = -1
-        with self.assertRaises(RuntimeWarning):
-            transform(sample)
+    def test_with_wrong_std_type(self):
+        """The transform raises an error if wrong type is given for std."""
+        with self.assertRaises(TypeError):
+            RandomLabelsToImage(label_key='label', std=42)
+
+    def test_with_wrong_std_elements_type(self):
+        """The transform raises an error if wrong type are given for
+        std elements."""
+        with self.assertRaises(ValueError):
+            RandomLabelsToImage(label_key='label', std=['wrong'])
+
+    def test_mean_and_std_len_not_matching(self):
+        """The transform raises an error if mean and std length don't match."""
+        with self.assertRaises(AssertionError):
+            RandomLabelsToImage(label_key='label', mean=[0], std=[0, 1])
+
+    def test_mean_and_used_labels_len_not_matching(self):
+        """The transform raises an error if mean and used_labels
+         length don't match."""
+        with self.assertRaises(AssertionError):
+            RandomLabelsToImage(label_key='label', mean=[0], used_labels=[0, 1])
+
+    def test_std_and_used_labels_len_not_matching(self):
+        """The transform raises an error if std and used_labels
+         length don't match."""
+        with self.assertRaises(AssertionError):
+            RandomLabelsToImage(label_key='label', std=[0], used_labels=[0, 1])
+
+    def test_mean_not_matching_number_of_labels(self):
+        """The transform raises an error at runtime if mean length
+        does not match label numbers."""
+        transform = RandomLabelsToImage(label_key='label', mean=[0])
+        with self.assertRaises(AssertionError):
+            transform(self.sample)
+
+    def test_std_not_matching_number_of_labels(self):
+        """The transform raises an error at runtime if std length
+        does not match label numbers."""
+        transform = RandomLabelsToImage(label_key='label', std=[1, 2, 3])
+        with self.assertRaises(AssertionError):
+            transform(self.sample)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -107,6 +107,19 @@ class TorchioTestCase(unittest.TestCase):
         image = ScalarImage(path)
         return image, path
 
+    def get_sample_with_partial_volume_label_map(self, components=1):
+        """Return a sample with a partial-volume label map."""
+        return Subject(
+            t1=ScalarImage(
+                self.get_image_path('t1_d'),
+            ),
+            label=LabelMap(
+                self.get_image_path(
+                    'label_d2', binary=False, components=components
+                )
+            ),
+        )
+
     def tearDown(self):
         """Tear down test fixtures, if any."""
         shutil.rmtree(self.dir)

--- a/torchio/transforms/augmentation/intensity/random_labels_to_image.py
+++ b/torchio/transforms/augmentation/intensity/random_labels_to_image.py
@@ -77,7 +77,7 @@ class RandomLabelsToImage(RandomTransform, IntensityTransform):
         ... )
         >>> blurring_transform = RandomBlur(std=0.3)
         >>> transform = Compose([simulation_transform, blurring_transform])
-        >>> transformed = transform(sample)  # sample has a new key 'image' with the simulated image
+        >>> transformed = transform(sample)  # sample has a new key 'image_from_labels' with the simulated image
         >>> # Filling holes of the simulated image with the original T1 image
         >>> rescale_transform = RescaleIntensity((0, 1), (1, 99))   # Rescale intensity before filling holes
         >>> simulation_transform = RandomLabelsToImage(
@@ -92,7 +92,7 @@ class RandomLabelsToImage(RandomTransform, IntensityTransform):
             self,
             label_key: str,
             used_labels: Optional[Sequence[int]] = None,
-            image_key: str = 'image',
+            image_key: str = 'image_from_labels',
             mean: Optional[Sequence[TypeRangeFloat]] = None,
             std: Optional[Sequence[TypeRangeFloat]] = None,
             default_mean: TypeRangeFloat = (0.1, 0.9),

--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -3,7 +3,7 @@ import gzip
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Union, Iterable, Tuple, Any, Optional, List
+from typing import Union, Iterable, Tuple, Any, Optional, List, Sequence
 
 import torch
 import numpy as np
@@ -325,3 +325,11 @@ def compress(input_path, output_path):
     with open(input_path, 'rb') as f_in:
         with gzip.open(output_path, 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)
+
+
+def check_sequence(sequence: Sequence, name: str):
+    try:
+        iter(sequence)
+    except TypeError:
+        message = f'"{name}" must be a sequence, not {type(name)}'
+        raise TypeError(message)


### PR DESCRIPTION
Refactor `RandomLabelsToImage` as discussed in https://github.com/fepegar/torchio/issues/253.

Examples have been rewritten using the ICBM template. Here are some images created using the examples:
- Using default parameters:
![Figure_1](https://user-images.githubusercontent.com/39873986/90017862-6da16200-dcac-11ea-868f-e8dfa9fb2169.png)
- Using `mean=[0.33, 0.66, 1]` and `std=[0, 0, 0]`:
![Figure_2](https://user-images.githubusercontent.com/39873986/90017866-6ed28f00-dcac-11ea-8e9f-902a64c601d5.png)
- Same as before but using `discretize=True`:
![Figure_3](https://user-images.githubusercontent.com/39873986/90017872-709c5280-dcac-11ea-8882-4fe52fb01bb4.png)
- Blurring precedent result:
![Figure_4](https://user-images.githubusercontent.com/39873986/90017886-72feac80-dcac-11ea-9c50-5d64c154c125.png)
- Filling CSF and background with T1 image:
![Figure_5](https://user-images.githubusercontent.com/39873986/90017888-73974300-dcac-11ea-89a6-82e45c91df4d.png)
