### PR TITLE
Use SimpleITK to resample

### DIFF
--- a/tests/transforms/preprocessing/test_resample.py
+++ b/tests/transforms/preprocessing/test_resample.py
@@ -32,13 +32,13 @@ class TestResample(TorchioTestCase):
         affine_name = 'pre_affine'
         transform = Resample(spacing, pre_affine_name=affine_name)
         transformed = transform(self.sample)
-        for image_dict in transformed.values():
-            if affine_name in image_dict.keys():
+        for image in transformed.values():
+            if affine_name in image:
                 new_affine = np.eye(4)
                 new_affine[0, 3] = 10
-                assert_array_equal(image_dict[AFFINE], new_affine)
+                assert_array_equal(image[AFFINE], new_affine)
             else:
-                assert_array_equal(image_dict[AFFINE], np.eye(4))
+                assert_array_equal(image[AFFINE], np.eye(4))
 
     def test_missing_affine(self):
         transform = Resample(1, pre_affine_name='missing')
@@ -69,3 +69,8 @@ class TestResample(TorchioTestCase):
         transform = Resample('missing')
         with self.assertRaises(ValueError):
             transform(self.sample)
+
+    def test_2d(self):
+        sample = self.make_2d(self.sample)
+        transform = Resample(2)
+        transform(sample)

--- a/tests/transforms/preprocessing/test_resample.py
+++ b/tests/transforms/preprocessing/test_resample.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 from torchio import DATA, AFFINE
 from torchio.transforms import Resample
 from torchio.utils import nib_to_sitk
@@ -34,9 +34,9 @@ class TestResample(TorchioTestCase):
         transformed = transform(self.sample)
         for image in transformed.values():
             if affine_name in image:
-                new_affine = np.eye(4)
-                new_affine[0, 3] = 10
-                assert_array_equal(image[AFFINE], new_affine)
+                target_affine = np.eye(4)
+                target_affine[:3, 3] = 10, 0, -0.1
+                assert_array_almost_equal(image[AFFINE], target_affine)
             else:
                 assert_array_equal(image[AFFINE], np.eye(4))
 

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -441,9 +441,9 @@ class Image(dict):
         """Get a NumPy array containing the image data."""
         return np.asarray(self)
 
-    def as_sitk(self) -> sitk.Image:
+    def as_sitk(self, **kwargs) -> sitk.Image:
         """Get the image as an instance of :py:class:`sitk.Image`."""
-        return nib_to_sitk(self[DATA], self[AFFINE])
+        return nib_to_sitk(self[DATA], self[AFFINE], **kwargs)
 
     def get_center(self, lps: bool = False) -> TypeTripletFloat:
         """Get image center in RAS+ or LPS+ coordinates.

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -5,13 +5,15 @@ from typing import Union, Tuple, Optional, List
 import torch
 import numpy as np
 import nibabel as nib
+import SimpleITK as sitk
 from nibabel.processing import resample_to_output, resample_from_to
 
 from ....data.subject import Subject
 from ....data.image import Image, ScalarImage
-from ....torchio import DATA, AFFINE, TYPE, INTENSITY, TypeData
+from ....torchio import DATA, AFFINE, TYPE, INTENSITY, TypeData, TypeTripletFloat
+from ....utils import sitk_to_nib
 from ... import SpatialTransform
-from ... import Interpolation
+from ... import Interpolation, get_sitk_interpolator
 
 
 
@@ -72,18 +74,22 @@ class Resample(SpatialTransform):
             ):
         super().__init__(p=p, keys=keys)
         self.reference_image, self.target_spacing = self.parse_target(target)
-        self.interpolation_order = self.parse_interpolation(image_interpolation)
+        self.interpolation = self.parse_interpolation(image_interpolation)
         self.affine_name = pre_affine_name
 
     def parse_target(
             self,
             target: Union[TypeSpacing, str],
             ) -> TypeTarget:
+        """
+        If target is an existing path, return a torchio.ScalarImage
+        If it does not exist, return the string
+        If it is not a Path or string, return None
+        """
         if isinstance(target, (str, Path)):
             if Path(target).is_file():
                 path = target
-                image = ScalarImage(path)
-                reference_image = image.data, image.affine
+                reference_image = ScalarImage(path)
             else:
                 reference_image = target
             target_spacing = None
@@ -107,20 +113,6 @@ class Resample(SpatialTransform):
         if np.any(np.array(spacing) <= 0):
             raise ValueError(f'Spacing must be positive, not "{spacing}"')
         return result
-
-    def parse_interpolation(self, interpolation: str) -> int:
-        interpolation = super().parse_interpolation(interpolation)
-
-        if interpolation in (Interpolation.NEAREST, 'nearest'):
-            order = 0
-        elif interpolation in (Interpolation.LINEAR, 'linear'):
-            order = 1
-        elif interpolation in (Interpolation.BSPLINE, 'bspline'):
-            order = 3
-        else:
-            message = f'Interpolation not implemented yet: {interpolation}'
-            raise NotImplementedError(message)
-        return order
 
     @staticmethod
     def check_affine(affine_name: str, image_dict: dict):
@@ -157,21 +149,21 @@ class Resample(SpatialTransform):
         raise ValueError(message)
 
     def apply_transform(self, sample: Subject) -> dict:
-        use_reference = self.reference_image is not None
         use_pre_affine = self.affine_name is not None
         if use_pre_affine:
             self.check_affine_key_presence(self.affine_name, sample)
         images_dict = self.get_images_dict(sample).items()
         for image_name, image in images_dict:
             # Do not resample the reference image if there is one
-            if use_reference and image_name == self.reference_image:
+            if image is self.reference_image:
                 continue
 
-            # Choose interpolator
+            # Choose interpolation
             if image[TYPE] != INTENSITY:
-                interpolation_order = 0  # nearest neighbor
+                interpolation = Interpolation.NEAREST
             else:
-                interpolation_order = self.interpolation_order
+                interpolation = self.interpolation
+            interpolator = get_sitk_interpolator(interpolation)
 
             # Apply given affine matrix if found in image
             if use_pre_affine and self.affine_name in image:
@@ -181,62 +173,52 @@ class Resample(SpatialTransform):
                     matrix = matrix.numpy()
                 image[AFFINE] = matrix @ image[AFFINE]
 
+            floating_itk = image.as_sitk(force_3d=True)
+
             # Resample
-            if use_reference:
-                if isinstance(self.reference_image, str):
-                    try:
-                        ref_image = sample[self.reference_image]
-                    except KeyError as error:
-                        message = (
-                            f'Reference name "{self.reference_image}"'
-                            ' not found in sample'
-                        )
-                        raise ValueError(message) from error
-                    reference = ref_image[DATA], ref_image[AFFINE]
-                else:
-                    reference = self.reference_image
-                kwargs = dict(reference=reference)
-            else:
-                kwargs = dict(target_spacing=self.target_spacing)
-            image[DATA], image[AFFINE] = self.apply_resample(
-                image[DATA],
-                image[AFFINE],
-                interpolation_order,
-                **kwargs,
-            )
+            if isinstance(self.reference_image, str):
+                try:
+                    reference_image_sitk = sample[self.reference_image].as_sitk()
+                except KeyError as error:
+                    message = (
+                        f'Reference name "{self.reference_image}"'
+                        ' not found in sample'
+                    )
+                    raise ValueError(message) from error
+            elif isinstance(self.reference_image, ScalarImage):
+                reference_image_sitk = self.reference_image.as_sitk()
+            elif self.reference_image is None:  # target is a spacing
+                reference_image_sitk = self.get_reference_image(
+                    floating_itk,
+                    self.target_spacing,
+                )
+
+            resampler = sitk.ResampleImageFilter()
+            resampler.SetInterpolator(interpolator)
+            resampler.SetReferenceImage(reference_image_sitk)
+            resampled = resampler.Execute(floating_itk)
+
+            image[DATA], image[AFFINE] = sitk_to_nib(resampled)
         return sample
 
     @staticmethod
-    def apply_resample(
-            tensor: torch.Tensor,
-            affine: np.ndarray,
-            interpolation_order: int,
-            target_spacing: Optional[Tuple[float, float, float]] = None,
-            reference: Optional[Tuple[torch.Tensor, np.ndarray]] = None,
-            ) -> Tuple[torch.Tensor, np.ndarray]:
-        array = tensor.numpy()
-        niis = []
-        arrays_resampled = []
-        if reference is None:
-            for channel in array:
-                nii = resample_to_output(
-                    nib.Nifti1Image(channel, affine),
-                    voxel_sizes=target_spacing,
-                    order=interpolation_order,
-                )
-                arrays_resampled.append(nii.get_fdata(dtype=np.float32))
-        else:
-            reference_tensor, reference_affine = reference
-            reference_array = reference_tensor.numpy()[0]
-            for channel_array in array:
-                nii = resample_from_to(
-                    nib.Nifti1Image(channel_array, affine),
-                    nib.Nifti1Image(reference_array, reference_affine),
-                    order=interpolation_order,
-                )
-                arrays_resampled.append(nii.get_fdata(dtype=np.float32))
-        tensor = torch.Tensor(arrays_resampled)
-        return tensor, nii.affine
+    def get_reference_image(
+            image: sitk.Image,
+            spacing: TypeTripletFloat,
+            ) -> sitk.Image:
+        old_spacing = np.array(image.GetSpacing())
+        new_spacing = np.array(spacing)
+        old_size = np.array(image.GetSize())
+        new_size = old_size * old_spacing / new_spacing
+        new_size = np.ceil(new_size).astype(np.uint16)
+        new_origin_index = 0.5 * (new_spacing / old_spacing - 1)
+        new_origin_lps = image.TransformContinuousIndexToPhysicalPoint(
+            new_origin_index)
+        reference = sitk.Image(*new_size.tolist(), sitk.sitkFloat32)
+        reference.SetDirection(image.GetDirection())
+        reference.SetSpacing(new_spacing.tolist())
+        reference.SetOrigin(new_origin_lps)
+        return reference
 
     @staticmethod
     def get_sigma(downsampling_factor, spacing):

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -4,7 +4,6 @@ from typing import Union, Tuple, Optional, List
 
 import torch
 import numpy as np
-import nibabel as nib
 import SimpleITK as sitk
 from nibabel.processing import resample_to_output, resample_from_to
 
@@ -45,11 +44,6 @@ class Resample(SpatialTransform):
             but will be removed in a future version.
         p: Probability that this transform will be applied.
         keys: See :py:class:`~torchio.transforms.Transform`.
-
-    .. note:: Resampling is performed using
-        :py:meth:`nibabel.processing.resample_to_output` or
-        :py:meth:`nibabel.processing.resample_from_to`, depending on whether
-        the target is a spacing or a reference image.
 
     Example:
         >>> import torchio


### PR DESCRIPTION
Fixes #271.
Resolves #227.

# Benchmark with Colin 1998 T1 (1 mm iso)

## Upsample (0.87 mm iso)
Old nearest: **2.35 s ± 360 ms**
Old linear: 2.9 s ± 567 ms
New nearest: **326 ms ± 13.8 ms**
New linear: 561 ms ± 233 ms

## Downsample (1.87 mm iso)
Old nearest: 236 ms ± 15.3 ms
Old linear: 335 ms ± 58.9 ms
New nearest: 236 ms ± 12.7 ms
New linear: 244 ms ± 12.1 ms

