### PR TITLE
Faster implementation for UniformSampler

### DIFF
--- a/tests/data/sampler/test_uniform_sampler.py
+++ b/tests/data/sampler/test_uniform_sampler.py
@@ -14,16 +14,6 @@ class TestUniformSampler(TorchioTestCase):
         fixtures = torch.ones_like(probabilities)
         assert torch.all(probabilities.eq(fixtures))
 
-    def test_processed_uniform_probabilities(self):
-        sampler = UniformSampler(5)
-        probabilities = sampler.get_probability_map(self.sample)
-        probabilities = sampler.process_probability_map(probabilities)
-        fixtures = np.zeros_like(probabilities)
-        # Other positions cannot be patch centers
-        fixtures[2:-2, 2:-2, 2:-2] = probabilities[2, 2, 2]
-        self.assertAlmostEqual(probabilities.sum(), 1)
-        assert np.equal(probabilities, fixtures).all()
-
     def test_incosistent_shape(self):
         # https://github.com/fepegar/torchio/issues/234#issuecomment-675029767
         sample = torchio.Subject(

--- a/torchio/data/sampler/uniform.py
+++ b/torchio/data/sampler/uniform.py
@@ -30,5 +30,5 @@ class UniformSampler(RandomSampler):
             raise RuntimeError(message)
 
         valid_range = sample.spatial_shape - self.patch_size
-        corners = np.random.randint(valid_range + 1)
+        corners = np.asarray([torch.randint(x+1,(1,)).item() for x in valid_range])
         yield self.extract_patch(sample, corners)

--- a/torchio/data/sampler/uniform.py
+++ b/torchio/data/sampler/uniform.py
@@ -1,10 +1,12 @@
 import torch
 from ...data.subject import Subject
 from ...torchio import TypePatchSize
-from .weighted import WeightedSampler
+from .sampler import RandomSampler
+from typing import Optional, Tuple, Generator
+import numpy as np
 
 
-class UniformSampler(WeightedSampler):
+class UniformSampler(RandomSampler):
     """Randomly extract patches from a volume with uniform probability.
 
     Args:
@@ -15,3 +17,18 @@ class UniformSampler(WeightedSampler):
 
     def get_probability_map(self, sample: Subject) -> torch.Tensor:
         return torch.ones(1, *sample.spatial_shape)
+
+    def __call__(self, sample: Subject) -> Generator[Subject, None, None]:
+
+        sample.check_consistent_spatial_shape()
+
+        if np.any(self.patch_size > sample.spatial_shape):
+            message = (
+                f'Patch size {tuple(self.patch_size)} cannot be'
+                f' larger than image size {tuple(sample.spatial_shape)}'
+            )
+            raise RuntimeError(message)
+
+        valid_range = sample.spatial_shape - self.patch_size
+        corners = np.random.randint(valid_range + 1)
+        yield self.extract_patch(sample, corners)

--- a/torchio/data/sampler/uniform.py
+++ b/torchio/data/sampler/uniform.py
@@ -19,7 +19,6 @@ class UniformSampler(RandomSampler):
         return torch.ones(1, *sample.spatial_shape)
 
     def __call__(self, sample: Subject) -> Generator[Subject, None, None]:
-
         sample.check_consistent_spatial_shape()
 
         if np.any(self.patch_size > sample.spatial_shape):
@@ -30,5 +29,6 @@ class UniformSampler(RandomSampler):
             raise RuntimeError(message)
 
         valid_range = sample.spatial_shape - self.patch_size
-        corners = np.asarray([torch.randint(x+1,(1,)).item() for x in valid_range])
-        yield self.extract_patch(sample, corners)
+        index_ini = [torch.randint(x + 1, (1,)).item() for x in valid_range]
+        index_ini_array = np.asarray(index_ini)
+        yield self.extract_patch(sample, index_ini_array)


### PR DESCRIPTION
I found that the Uniform Sampler could be awfully slow for large volumes.
In my workflow, i have 512x512x ~800 large volumes, and i extract many patches  (e.g. 64) from each volume.
With these sizes, the extraction takes way slower time than the calculation of patch location.
This is because  UniformSampler uses the WeightedSampler, and WS calculates CDF every time,
this can be very time (and memory) consuming. This calculation grows linearly with the volume size,
and not with the patch size. 

However, generating the coordinates directly is cheap and simple, see the proposed implementation. 
I am not against keeping the get_probability_map method, if someone wants to use it for something else too,
(keeping the API similar for all methods, etc.), but i think it is unnecearry to use it for the calculations.
(But i am also not against removing it.)

Most of the code is trivial, one remark about the size: if the patch is as large as the volume, the valid range would be 0.
This is mostly fine, but randint is not inclusive, it will generate in 0..N-1 range, so we need to add +1, otherwise it would not be able to yield a patch as large as the volume. 
