### PR TITLE
Multichannel label sampler

### DIFF
--- a/torchio/data/sampler/label.py
+++ b/torchio/data/sampler/label.py
@@ -82,15 +82,25 @@ class LabelSampler(WeightedSampler):
             label_probabilities_dict: Dict[int, float],
             ) -> torch.Tensor:
         """Create probability map according to label map probabilities."""
+        multichannel = label_map.shape[0] > 1
         probability_map = torch.zeros_like(label_map)
         label_probs = torch.Tensor(list(label_probabilities_dict.values()))
         normalized_probs = label_probs / label_probs.sum()
         iterable = zip(label_probabilities_dict, normalized_probs)
         for label, label_probability in iterable:
-            mask = label_map == label
+            if multichannel:
+                mask = label_map[label]
+            else:
+                mask = label_map == label
             label_size = mask.sum()
             if not label_size:
                 continue
             prob_voxels = label_probability / label_size
             probability_map[mask] = prob_voxels
+            if multichannel:
+                probability_map[label] = prob_voxels * mask
+            else:
+                probability_map[mask] = prob_voxels
+        if multichannel:
+            probability_map = probability_map.sum(dim=0, keepdim=True)
         return probability_map

--- a/torchio/data/sampler/label.py
+++ b/torchio/data/sampler/label.py
@@ -26,6 +26,11 @@ class LabelSampler(WeightedSampler):
             labeled as ``1``, 25% of being ``2`` and 25% of being ``3``.
             If ``None``, the label map is binarized and the value is set to
             ``{0: 0, 1: 1}``.
+            If the input has multiple channels, a value of
+            ``{0: 0, 1: 2, 2: 1, 3: 1}`` will create a
+            sampler whose patches centers will have 50% probability of being
+            taken from a non zero value of channel ``1``, 25% from channel
+            ``2`` and 25% from channel ``3``.
 
     Example:
         >>> import torchio


### PR DESCRIPTION
Fixes #291 
Update `LabelSampler` to change its behaviour if the input has more than 1 channel. In such a case, keys from the `label_probabilities` dictionary no longer represent label values but label channels instead. 