### PR TITLE
Faster WeightedSampler implementation

### DIFF
--- a/torchio/data/sampler/weighted.py
+++ b/torchio/data/sampler/weighted.py
@@ -246,7 +246,7 @@ class WeightedSampler(RandomSampler):
         if random_number > cdf.max():
             cdf_index = -1
         else:  # proceed as usual
-            cdf_index = np.argmax(random_number < cdf)
+            cdf_index = np.searchsorted(cdf, random_number)
 
         random_location_index = sort_indices[cdf_index]
         center = np.unravel_index(


### PR DESCRIPTION
Np.sortedsearch performs binary search, which is logN steps, instead of
the arithmetics on the full array and then a linear search (argmax).