### PR TITLE
Handle negative input values in RandomGamma

### DIFF
--- a/tests/transforms/augmentation/test_random_gamma.py
+++ b/tests/transforms/augmentation/test_random_gamma.py
@@ -1,3 +1,4 @@
+import torch
 from torchio import RandomGamma
 from ...utils import TorchioTestCase
 
@@ -31,3 +32,7 @@ class TestRandomGamma(TorchioTestCase):
     def test_wrong_gamma_type(self):
         with self.assertRaises(ValueError):
             RandomGamma(log_gamma='wrong')
+
+    def test_negative_values(self):
+        with self.assertWarns(UserWarning):
+            RandomGamma()(torch.rand(1, 3, 3, 3) - 1)


### PR DESCRIPTION
Fixes #306.

The new warning in the docs looks like this:
<img width="672" alt="Screen Shot 2020-09-21 at 11 12 24" src="https://user-images.githubusercontent.com/12688084/93755537-5df63100-fbfb-11ea-9d25-8246a53faaf8.png">

@GFabien can you please take a look?