### PR TITLE
Add pre-commit support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-      - id: check-added-large-file     # Prevent giant files from being committed
       - id: check-ast                  # Simply check whether the files parse as valid python
       - id: check-case-conflict        # Check for files that would conflict in case-insensitive filesystems
       - id: check-builtin-literals     # Require literal syntax when initializing empty or zero Python builtin types
@@ -17,6 +16,8 @@ repos:
       - id: end-of-file-fixer          # Ensures that a file is either empty, or ends with one newline
       - id: mixed-line-ending          # Replaces or checks mixed line ending
       - id: trailing-whitespace        # This hook trims trailing whitespace
+      - id: file-contents-sorter       # Sort the lines in specified files
+        files: ^requirements.*\.txt$
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,72 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: exclude-unwanted
+        name: exclude unwanted files, e.g. training data
+        entry: exclude unwanted files, e.g. training data
+        language: fail
+        files: '.*xlsx|.*dcm|.*pyc'
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: check-added-large-files
+    -   id: check-case-conflict
+    -   id: check-ast
+    -   id: check-executables-have-shebangs
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-toml
+    -   id: check-xml
+    -   id: check-vcs-permalinks
+    -   id: check-xml
+    -   id: detect-private-key
+    -   id: pretty-format-json
+    -   id: requirements-txt-fixer
+    -   id: sort-simple-yaml
+    -   id: mixed-line-ending
+    -   id: debug-statements
+    -   id: pretty-format-json
+    -   id: end-of-file-fixer
+        args: ['--autofix']
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+    -   id: flake8
+        additional_dependencies: [
+#            flake8-bandit,
+            flake8-blind-except,
+            flake8-breakpoint,
+            flake8-broken-line,
+            flake8-bugbear,
+            flake8-builtins,
+            flake8-class-newline,
+            flake8-comprehensions,
+#            flake8-debugger,
+#            flake8-eradicate,
+#            flake8-logging-format,
+#            flake8-pep3101,
+#            flake8-polyfill,
+#            flake8-quotes,
+#            flake8-string-format,
+            flake8-type-annotations,
+#            flake8-use-fstring,
+#            flake8-fixme,
+            flake8-markdown,
+            flake8-2020,
+#            flake8-print,
+#            pep8-naming
+             ]
+        args: ['--max-line-length=160', '--ignore=E121,E123,E125,E501,F401,F403,W503']
+
+-   repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.6.0  # Use the ref you want to point at
+    hooks:
+    -   id: python-check-blanket-noqa
+    -   id: python-no-log-warn
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.2
+    hooks:
+    -   id: pyupgrade
+        args: ['--py36-plus']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,72 +1,60 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: local
-    hooks:
-    -   id: exclude-unwanted
-        name: exclude unwanted files, e.g. training data
-        entry: exclude unwanted files, e.g. training data
-        language: fail
-        files: '.*xlsx|.*dcm|.*pyc'
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: check-added-large-files
-    -   id: check-case-conflict
-    -   id: check-ast
-    -   id: check-executables-have-shebangs
-    -   id: check-json
-    -   id: check-merge-conflict
-    -   id: check-symlinks
-    -   id: check-toml
-    -   id: check-xml
-    -   id: check-vcs-permalinks
-    -   id: check-xml
-    -   id: detect-private-key
-    -   id: pretty-format-json
-    -   id: requirements-txt-fixer
-    -   id: sort-simple-yaml
-    -   id: mixed-line-ending
-    -   id: debug-statements
-    -   id: pretty-format-json
-    -   id: end-of-file-fixer
-        args: ['--autofix']
--   repo: https://gitlab.com/pycqa/flake8
+      - id: check-added-large-file     # Prevent giant files from being committed
+      - id: check-ast                  # Simply check whether the files parse as valid python
+      - id: check-case-conflict        # Check for files that would conflict in case-insensitive filesystems
+      - id: check-builtin-literals     # Require literal syntax when initializing empty or zero Python builtin types
+      - id: check-docstring-first      # Checks a common error of defining a docstring after code
+      - id: check-merge-conflict       # Check for files that contain merge conflict strings
+      - id: check-vcs-permalinks       # Ensures that links to vcs websites are permalinks
+      - id: debug-statements           # Check for debugger imports and py37+ `breakpoint()` calls in python source
+      - id: detect-private-key         # Detects the presence of private keys
+      - id: double-quote-string-fixer  # Replaces double quoted strings with single quoted strings.
+      - id: end-of-file-fixer          # Ensures that a file is either empty, or ends with one newline
+      - id: mixed-line-ending          # Replaces or checks mixed line ending
+      - id: trailing-whitespace        # This hook trims trailing whitespace
+  - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:
-    -   id: flake8
+      - id: flake8
         additional_dependencies: [
-#            flake8-bandit,
-            flake8-blind-except,
-            flake8-breakpoint,
-            flake8-broken-line,
-            flake8-bugbear,
-            flake8-builtins,
-            flake8-class-newline,
-            flake8-comprehensions,
-#            flake8-debugger,
-#            flake8-eradicate,
-#            flake8-logging-format,
-#            flake8-pep3101,
-#            flake8-polyfill,
-#            flake8-quotes,
-#            flake8-string-format,
-            flake8-type-annotations,
-#            flake8-use-fstring,
-#            flake8-fixme,
-            flake8-markdown,
-            flake8-2020,
-#            flake8-print,
-#            pep8-naming
-             ]
-        args: ['--max-line-length=160', '--ignore=E121,E123,E125,E501,F401,F403,W503']
-
--   repo: https://github.com/pre-commit/pygrep-hooks
+          flake8-blind-except,      # check for blind, catch-all "except:" statements
+          flake8-breakpoint,        # check forgotten breakpoints
+          flake8-broken-line,       # forbid backslashes for line breaks
+          flake8-bugbear,           # find likely bugs and design problems
+          flake8-builtins,          # check for python builtins being used as variables or parameters
+          flake8-class-newline,     # lint for newline after class definitions
+          flake8-comprehensions,    # write better list/set/dict comprehensions
+          flake8-debugger,          # check for pdb;idbp imports and set traces
+          flake8-fixme,             # check for FIXME, TODO and other temporary developer notes
+          flake8-logging-format,    # validate (lack of) logging format strings
+          flake8-markdown,          # lint Python code blocks in Markdown files using flake8
+          flake8-pep3101,           # check for old string formatting
+          flake8-polyfill,          # help support Flake8 2.x and 3.x simultaneously
+          flake8-print,             # check for Print statements
+          flake8-type-annotations,  # enforce consistent type annotation styles
+          flake8-use-fstring,       # enforce use of f-string
+          flake8-2020,              # check for misuse of `sys.version` or `sys.version_info`
+          pep8-naming,              # check PEP-8 naming conventions
+        ]
+        args: [
+          '--max-line-length=160',
+          '--ignore=E121,E123,E125,E501,F401,F403,W503,N813',
+        ]
+  - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.6.0  # Use the ref you want to point at
     hooks:
-    -   id: python-check-blanket-noqa
-    -   id: python-no-log-warn
--   repo: https://github.com/asottile/pyupgrade
+      - id: python-check-blanket-noqa  # enforce that noqa annotations always occur with specific codes
+      - id: python-no-log-warn  # check for the deprecated .warn() method of python loggers
+      - id: python-use-type-annotations  # enforce that python3.6+ type annotations are used instead of type comments
+      - id: rst-backticks  # detect common mistake of using single backticks when writing rst
+      - id: rst-inline-touching-normal  # detect mistake of inline code touching normal text in rst
+  - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2
     hooks:
-    -   id: pyupgrade
+      - id: pyupgrade
         args: ['--py36-plus']

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ at [OpenAI](https://openai.com/) ([link](https://jack-clark.net/2020/03/17/)).
             <a href="https://codeclimate.com/github/fepegar/torchio/maintainability">
                 <img src="https://api.codeclimate.com/v1/badges/518673e49a472dd5714d/maintainability" alt="Code maintainability">
             </a>
+            <a href="https://github.com/pre-commit/pre-commit">
+                <img src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white" alt="pre-commit">
+            </a>
         </td>
     </tr>
     <tr>

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -4,7 +4,7 @@ TorchIO
 
 |PyPI-downloads| |PyPI-version| |Google-Colab-notebook| |Docs-status|
 |Build-status| |Coverage-codecov| |Coverage-coveralls| |Code-Quality|
-|Code-Maintainability| |Slack|
+|Code-Maintainability| |pre-commit| |Slack|
 
 
 TorchIO is a Python library for efficient loading, preprocessing, augmentation
@@ -98,3 +98,7 @@ This package has been greatly inspired by `NiftyNet <https://niftynet.io/>`_.
 .. |Code-Maintainability| image:: https://api.codeclimate.com/v1/badges/518673e49a472dd5714d/maintainability
    :target: https://codeclimate.com/github/fepegar/torchio/maintainability
    :alt: Maintainability
+
+.. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
+   :target: https://github.com/pre-commit/pre-commit
+   :alt: pre-commit

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,3 +15,4 @@ tox
 twine
 watchdog
 wheel
+pre-commit

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ coveralls
 flake8
 mypy
 pip
+pre-commit
 pylint
 pytest
 pytest-cov
@@ -15,4 +16,4 @@ tox
 twine
 watchdog
 wheel
-pre-commit
+

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,13 @@ setenv =
 deps = flake8
 commands = flake8 .
 
+[testenv:pre-commit]
+description = format the code
+deps =
+    pre-commit
+commands =
+    pre-commit run --all-files --show-diff-on-failure
+
 [travis]
 python =
     3.8: py38


### PR DESCRIPTION
Add pre-commit support for development, see #315.
The actual checks might need customization, it reflects mostly my preference,
and i already commented out some which are whining a lot.
(I would use them, but it is not my project.)

Also i have an auto code formating hooks (autopep8), but some people prefer
black, or yapf, or else. 

If you check out the config, you will see how to disable invidiual reports.

Caching: first run takes time, the rest is fast. (Try run it twice in a row.)
