### PR TITLE
Update rescale.py

### DIFF
--- a/torchio/transforms/preprocessing/intensity/rescale.py
+++ b/torchio/transforms/preprocessing/intensity/rescale.py
@@ -20,7 +20,7 @@ class RescaleIntensity(NormalizationTransform):
         percentiles: Percentile values of the input image that will be mapped
             to :math:`(n_{min}, n_{max})`. They can be used for contrast
             stretching, as in `this scikit-image example`_. For example,
-            Isensee et al. use ``(0.05, 99.5)`` in their `nn-UNet paper`_.
+            Isensee et al. use ``(0.005, 0.995)`` in their `nn-UNet paper`_.
             If only one value :math:`d` is provided,
             :math:`(n_{min}, n_{max}) = (0, d)`.
         masking_method: See

--- a/torchio/transforms/preprocessing/intensity/rescale.py
+++ b/torchio/transforms/preprocessing/intensity/rescale.py
@@ -20,7 +20,7 @@ class RescaleIntensity(NormalizationTransform):
         percentiles: Percentile values of the input image that will be mapped
             to :math:`(n_{min}, n_{max})`. They can be used for contrast
             stretching, as in `this scikit-image example`_. For example,
-            Isensee et al. use ``(0.005, 0.995)`` in their `nn-UNet paper`_.
+            Isensee et al. use ``(0.5, 99.5)`` in their `nn-UNet paper`_.
             If only one value :math:`d` is provided,
             :math:`(n_{min}, n_{max}) = (0, d)`.
         masking_method: See


### PR DESCRIPTION
fix typo: nnU-Net uses 0.005 and 0.995 percentiles, see:
https://github.com/MIC-DKFZ/nnUNet/blob/4d8aa747b288e4297236eb385ea325256634372c/nnunet/preprocessing/preprocessing.py#L278

if percentiles should be provided without the leading zero then it needs to say: 0.5 to 99.5 percentiles, however this would be a very unusual notation.