### PR TITLE
Added support for HDF5 Dataset as Image including lazy loading of patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ ENV/
 test_scripts/
 
 *DS_Store
+tester.py

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ requirements = [
     'torch>=1.1',
     'torchvision',
     'tqdm',
+    'h5py'
 ]
 
 setup(

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -3,6 +3,7 @@
 """Tests for Image."""
 
 import copy
+import h5py
 import torch
 import pytest
 import numpy as np
@@ -160,3 +161,63 @@ class TestImage(TorchioTestCase):
         width_idx = image.axis_name_to_index('l')
         self.assertEqual(image.height, image.shape[height_idx])
         self.assertEqual(image.width, image.shape[width_idx])
+
+    def test_h5ds_nolazypatch_crop(self):
+        path = self.get_h5DS_path('h5ds3D', shape=(10, 10, 10))
+        f = h5py.File(path, "r", swmr=True)
+        ds = f["data"]
+        image = ScalarImage(h5DS=ds, lazypatch=False)
+        assert image.spatial_shape == (10, 10, 10)
+        cropped_patch = image.crop((1,1,1), (5,5,5))
+        assert cropped_patch.spatial_shape == (4, 4, 4)
+
+    def test_h5ds_lazypatch_crop(self):
+        path = self.get_h5DS_path('h5ds3D', shape=(10, 10, 10))
+        f = h5py.File(path, "r", swmr=True)
+        ds = f["data"]
+        image = ScalarImage(h5DS=ds, lazypatch=True)
+        assert image.spatial_shape == (10, 10, 10)
+        cropped_patch = image.crop((1,1,1), (5,5,5))
+        assert cropped_patch.spatial_shape == (4, 4, 4)
+        
+    def test_h5ds_lazypatch_channelless(self):
+        path = self.get_h5DS_path('h5ds3D', shape=(10, 10, 10), no_channel_dim=True)
+        f = h5py.File(path, "r", swmr=True)
+        ds = f["data"]
+        image = ScalarImage(h5DS=ds, lazypatch=True)
+        assert image.spatial_shape == (10, 10, 10)
+        cropped_patch = image.crop((1,1,1), (5,5,5))
+        assert cropped_patch.spatial_shape == (4, 4, 4)
+
+    def test_h5ds_nolazypatch_channelless(self):
+        path = self.get_h5DS_path('h5ds3D', shape=(10, 10, 10), no_channel_dim=True)
+        f = h5py.File(path, "r", swmr=True)
+        ds = f["data"]
+        image = ScalarImage(h5DS=ds, lazypatch=False)
+        assert image.spatial_shape == (10, 10, 10)
+        cropped_patch = image.crop((1,1,1), (5,5,5))
+        assert cropped_patch.spatial_shape == (4, 4, 4)
+
+    def test_h5ds_nolazypatch_nan(self):
+        path = self.get_h5DS_path('h5ds3D', shape=(10, 10, 10), add_nans=True)
+        f = h5py.File(path, "r", swmr=True)
+        ds = f["data"]
+        with self.assertWarns(UserWarning):
+            image = ScalarImage(h5DS=ds, lazypatch=False, check_nans=True)
+        image.set_check_nans(False)
+
+    def test_h5ds_lazypatch_crop_nan(self):
+        path = self.get_h5DS_path('h5ds3D', shape=(10, 10, 10), add_nans=True)
+        f = h5py.File(path, "r", swmr=True)
+        ds = f["data"]
+        image = ScalarImage(h5DS=ds, lazypatch=True, check_nans=True)
+        with self.assertWarns(UserWarning):
+            cropped_patch = image.crop((1,1,1), (5,5,5))
+        image.set_check_nans(False)
+
+    def test_label_map_type_h5ds(self):
+        path = self.get_h5DS_path('h5ds3D', shape=(10, 10, 10), binary=True)
+        f = h5py.File(path, "r", swmr=True)
+        ds = f["data"]
+        label = LabelMap(h5DS=ds)
+        self.assertIs(label.type, LABEL)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ import random
 import tempfile
 import unittest
 from pathlib import Path
+import h5py
 
 import torch
 import numpy as np
@@ -168,3 +169,34 @@ class TorchioTestCase(unittest.TestCase):
 
     def assertTensorAlmostEqual(self, *args, **kwargs):  # noqa: N802
         assert_array_almost_equal(*args, **kwargs)
+
+    def get_h5DS_path(
+            self,
+            stem,
+            binary=False,
+            shape=(10, 20, 30),
+            spacing=(1, 1, 1),
+            components=1,
+            add_nans=False,
+            force_binary_foreground=True,
+            no_channel_dim=False
+            ):
+        shape = (*shape, 1) if len(shape) == 2 else shape
+        if no_channel_dim:
+            data = np.random.rand(*shape)
+        else:
+            data = np.random.rand(components, *shape)
+        if binary:
+            data = (data > 0.5).astype(np.uint8)
+            if not data.sum() and force_binary_foreground:
+                data[..., 0] = 1
+        if add_nans:
+            data[:] = np.nan
+        affine = np.diag((*spacing, 1))
+        suffix=".h5"
+        path = self.dir / f'{stem}{suffix}'
+        if np.random.rand() > 0.5:
+            path = str(path)
+        with h5py.File(path, "w") as f:
+            f.create_dataset("data", data=data)
+        return path

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -61,6 +61,11 @@ class Image(dict):
         tensor: If :py:attr:`path` is not given, :attr:`tensor` must be a 4D
             :py:class:`torch.Tensor` or NumPy array with dimensions
             :math:`(C, W, H, D)`.
+        h5DS: If both path and tensor aren't supplied, then an HDF5 Dataset has
+            to be supplied. 
+        lazypatch: Only applicable with h5DS. If ``True``, the h5DS won't be 
+            pre-loaded and lazy-loading will be performed while loading part 
+            of the volume as patch. If ``False``, the whole h5DS will be preloaded. 
         affine: If :attr:`path` is not given, :attr:`affine` must be a
             :math:`4 \times 4` NumPy array. If ``None``, :attr:`affine` is an
             identity matrix.
@@ -97,6 +102,8 @@ class Image(dict):
             path: Union[TypePath, Sequence[TypePath], None] = None,
             type: str = None,
             tensor: Optional[TypeData] = None,
+            h5DS: Optional[TypeData] = None,
+            lazypatch: bool = False,
             affine: Optional[TypeData] = None,
             check_nans: bool = False,  # removed by ITK by default
             channels_last: bool = False,
@@ -113,8 +120,8 @@ class Image(dict):
             )
             type = INTENSITY
 
-        if path is None and tensor is None:
-            raise ValueError('A value for path or tensor must be given')
+        if path is None and tensor is None and h5DS is None:
+            raise ValueError('A value for path or tensor or h5DS must be given')
         self._loaded = False
 
         tensor = self.parse_tensor(tensor)
@@ -127,6 +134,14 @@ class Image(dict):
             if key in kwargs:
                 message = f'Key "{key}" is reserved. Use a different one'
                 raise ValueError(message)
+
+        if h5DS is not None: #as no other affine is currently supplied inside the dataset
+            self[AFFINE] = affine
+
+        self.h5DS = h5DS
+        self.lazypatch = lazypatch
+        if h5DS and not lazypatch:
+            self.load()
 
         super().__init__(**kwargs)
         self.path = self._parse_path(path)
@@ -194,7 +209,10 @@ class Image(dict):
 
     @property
     def spatial_shape(self) -> TypeTripletInt:
-        return self.shape[1:]
+        if len(self.shape) == 3:
+            return self.shape
+        else:
+            return self.shape[1:]
 
     def check_is_2d(self):
         if not self.is_2d():
@@ -359,34 +377,45 @@ class Image(dict):
         """
         if self._loaded:
             return
-        paths = self.path if isinstance(self.path, list) else [self.path]
-        tensor, affine = self.read_and_check(paths[0])
-        tensors = [tensor]
-        for path in paths[1:]:
-            new_tensor, new_affine = self.read_and_check(path)
-            if not np.array_equal(affine, new_affine):
-                message = (
-                    'Files have different affine matrices.'
-                    f'\nMatrix of {paths[0]}:'
-                    f'\n{affine}'
-                    f'\nMatrix of {path}:'
-                    f'\n{new_affine}'
-                )
-                warnings.warn(message, RuntimeWarning)
-            if not tensor.shape[1:] == new_tensor.shape[1:]:
-                message = (
-                    f'Files shape do not match, found {tensor.shape}'
-                    f'and {new_tensor.shape}'
-                )
-                RuntimeError(message)
-            tensors.append(new_tensor)
-        tensor = torch.cat(tensors)
+        if self.h5DS: #If HDF5 Dataset has been supplied
+            if self.lazypatch:
+                tensor, affine = self.h5DS, self[AFFINE]
+            else:
+                tensor, affine = self.read_and_check(h5DS=self.h5DS)
+        else:
+            paths = self.path if isinstance(self.path, list) else [self.path]
+            tensor, affine = self.read_and_check(path=paths[0])
+            tensors = [tensor]
+            for path in paths[1:]:
+                new_tensor, new_affine = self.read_and_check(path=path)
+                if not np.array_equal(affine, new_affine):
+                    message = (
+                        'Files have different affine matrices.'
+                        f'\nMatrix of {paths[0]}:'
+                        f'\n{affine}'
+                        f'\nMatrix of {path}:'
+                        f'\n{new_affine}'
+                    )
+                    warnings.warn(message, RuntimeWarning)
+                if not tensor.shape[1:] == new_tensor.shape[1:]:
+                    message = (
+                        f'Files shape do not match, found {tensor.shape}'
+                        f'and {new_tensor.shape}'
+                    )
+                    RuntimeError(message)
+                tensors.append(new_tensor)
+            tensor = torch.cat(tensors)
         self[DATA] = tensor
         self[AFFINE] = affine
         self._loaded = True
 
-    def read_and_check(self, path):
-        tensor, affine = read_image(path)
+    def read_and_check(self, path=None, h5DS=None):
+        if h5DS:
+            tensor, affine = torch.from_numpy(h5DS[()]), self[AFFINE]
+            if len(tensor.shape) == 3: #channel missing
+                tensor = tensor.unsqueeze(0)
+        else:
+            tensor, affine = read_image(path)
         tensor = self.parse_tensor_shape(tensor)
         if self.channels_last:
             tensor = tensor.permute(3, 0, 1, 2)
@@ -445,12 +474,22 @@ class Image(dict):
         new_affine[:3, 3] = new_origin
         i0, j0, k0 = index_ini
         i1, j1, k1 = index_fin
-        patch = self.data[:, i0:i1, j0:j1, k0:k1].clone()
+        if isinstance(self.data, torch.Tensor):
+            patch = self.data[:, i0:i1, j0:j1, k0:k1].clone()
+        else:
+            if len(self.data.shape) == 4:
+                patch = self.data[:, i0:i1, j0:j1, k0:k1]
+            else:
+                patch = np.expand_dims(self.data[i0:i1, j0:j1, k0:k1], 0)
+            patch = torch.from_numpy(patch)
+            if self.check_nans and torch.isnan(patch).any():
+                warnings.warn(f'NaNs found in the dataset')
         kwargs = dict(
             tensor=patch,
             affine=new_affine,
             type=self.type,
             path=self.path,
+            h5DS=self.h5DS
         )
         for key, value in self.items():
             if key in PROTECTED_KEYS: continue


### PR DESCRIPTION
Will be able to use HDF5 datasets instead of path or tensor for creation of Image. The dataset can either be in (CxHxWxD) or even (HxWxD) format. If its the later, then the data will be expended for channel dim.
With the lazypatch parameter, will be able to enable or disable lazy loading of patches (only the patched portion of the volume will be loaded in the memory from the HDF5 Dataset).
 
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
