### PR TITLE
Fix variance scaling in random blur

### DIFF
--- a/torchio/transforms/augmentation/intensity/random_blur.py
+++ b/torchio/transforms/augmentation/intensity/random_blur.py
@@ -64,7 +64,7 @@ def blur(
         std_voxel: np.ndarray,
         ) -> torch.Tensor:
     assert data.ndim == 3
-    std_physical = np.array(std_voxel) * np.array(spacing)
+    std_physical = np.array(std_voxel) / np.array(spacing)
     blurred = ndi.gaussian_filter(data, std_physical)
     tensor = torch.from_numpy(blurred)
     return tensor


### PR DESCRIPTION
Fixes #337.

As scipy does not take into account image spacing for the gaussian
filter, the standard deviation of the kernels need to be scaled
accordingly.

The std needs to be divided by the spacing, not multiplied.

E.g.:
- If it is 1 mm for a 1 mm pixel, it should span 1 voxel = 1mm.
- If it is 1 mm for a 5 mm pixel, it should span 0.2 voxels = 1 mm.
