### PR TITLE
Fix Subject header in docs

### DIFF
--- a/docs/source/data/subject.rst
+++ b/docs/source/data/subject.rst
@@ -1,5 +1,5 @@
 #####
-Image
+Subject
 #####
 
 The :class:`~torchio.data.subject.Subject` is a data structure used to store

--- a/docs/source/data/subject.rst
+++ b/docs/source/data/subject.rst
@@ -1,6 +1,6 @@
-#####
+#######
 Subject
-#####
+#######
 
 The :class:`~torchio.data.subject.Subject` is a data structure used to store
 images associated with a subject and any other metadata necessary for


### PR DESCRIPTION
**Description**
A minor typo in the docs, right now there are two "Image" headers instead of "Image" and "Subject"