### PR TITLE
Fixes to internal references in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,6 +54,7 @@ intersphinx_mapping = {
     'torch': ('https://pytorch.org/docs/master/', None),  # https://github.com/pytorch/fairseq/blob/adb5b9c71f7ef4fe2f258e0da102d819ab9920ef/docs/conf.py#L131
     'torchvision': ('https://pytorch.org/docs/master/', None),
     'nibabel': ('https://nipy.org/nibabel/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/data/image.rst
+++ b/docs/source/data/image.rst
@@ -2,7 +2,7 @@
 Image
 #####
 
-The :class:`Image` class, representing one medical image,
+The :class:`~torchio.data.Image` class, representing one medical image,
 stores a 4D tensor, whose voxels encode, e.g., signal intensity or segmentation
 labels, and the corresponding affine transform,
 typically a rigid (Euclidean) transform, to convert
@@ -10,23 +10,23 @@ voxel indices to world coordinates in mm.
 Arbitrary fields such as acquisition parameters may also be stored.
 
 Subclasses are used to indicate specific types of images,
-such as :class:`ScalarImage` and :class:`LabelMap`,
+such as :class:`~torchio.data.ScalarImage` and :class:`~torchio.data.LabelMap`,
 which are used to store, e.g., CT scans and segmentations, respectively.
 
-An instance of :class:`Image` can be created using a filepath, a PyTorch tensor,
+An instance of :class:`~torchio.data.Image` can be created using a filepath, a PyTorch tensor,
 or a NumPy array.
 This class uses lazy loading, i.e., the data is not loaded from disk at
 instantiation time.
 Instead, the data is only loaded when needed for an operation
 (e.g., if a transform is applied to the image).
 
-The figure below shows two instances of :class:`Image`.
-The instance of :class:`ScalarImage` contains a 4D tensor representing a
+The figure below shows two instances of :class:`~torchio.data.Image`.
+The instance of :class:`~torchio.data.ScalarImage` contains a 4D tensor representing a
 diffusion MRI, which contains four 3D volumes (one per gradient direction),
 and the associated affine matrix.
 Additionally, it stores the strength and direction for each of the four
 gradients.
-The instance of :class:`LabelMap` contains a brain parcellation of the same
+The instance of :class:`~torchio.data.LabelMap` contains a brain parcellation of the same
 subject, the associated affine matrix, and the name and color of each brain
 structure.
 

--- a/docs/source/data/subject.rst
+++ b/docs/source/data/subject.rst
@@ -2,11 +2,11 @@
 Subject
 #######
 
-The :class:`~torchio.data.subject.Subject` is a data structure used to store
+The :class:`~torchio.data.Subject` is a data structure used to store
 images associated with a subject and any other metadata necessary for
 processing.
 
-All transforms applied to a :class:`~torchio.data.subject.Subject` are saved
+All transforms applied to a :class:`~torchio.data.Subject` are saved
 in its :attr:`history` attribute (see :ref:`Reproducibility`).
 
 .. currentmodule:: torchio.data

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -30,7 +30,7 @@ Hello, World!
 =============
 
 This example shows the basic usage of TorchIO, where an instance of
-:class:`~torchio.data.dataset.SubjectsDataset` is passed to
+:class:`~torchio.data.SubjectsDataset` is passed to
 a PyTorch :class:`~torch.utils.data.DataLoader` to generate training batches
 of 3D images that are loaded, preprocessed and augmented on the fly,
 in parallel::

--- a/docs/source/transforms/transforms.rst
+++ b/docs/source/transforms/transforms.rst
@@ -2,8 +2,8 @@ Transforms
 ----------
 
 TorchIO transforms take as input instances of
-:class:`~torchio.data.subject.Subject` or
-:class:`~torchio.data.image.Image` (and its subclasses), 4D PyTorch tensors,
+:class:`~torchio.data.Subject` or
+:class:`~torchio.data.Image` (and its subclasses), 4D PyTorch tensors,
 4D NumPy arrays, SimpleITK images, NiBabel images, or Python dictionaries
 (see :class:`~torchio.transforms.Transform`).
 
@@ -76,7 +76,7 @@ used to sample the transform parameters when the :meth:`__call__` method of the
 transform is called, i.e., when the transform instance is called.
 
 All random transforms have a corresponding deterministic class, that can be
-applied again to obtain exactly the same result. The :class:`Subject` class
+applied again to obtain exactly the same result. The :class:`~torchio.data.Subject` class
 contains some convenience methods to reproduce transforms::
 
     >>> import torchio as tio
@@ -147,8 +147,8 @@ invertibility:
 - Impossible: transforms that cannot be inverted, such as
   :class:`~torchio.transforms.RandomBlur`.
 
-Non-invertible transforms will be ignored by the :meth:`apply_inverse_transform`
-method of :class:`~torchio.data.subject.Subject`.
+Non-invertible transforms will be ignored by the :meth:`~torchio.data.Subject.apply_inverse_transform`
+method of :class:`~torchio.data.Subject`.
 
 
 .. _Interpolation:

--- a/torchio/data/__init__.py
+++ b/torchio/data/__init__.py
@@ -5,6 +5,7 @@ from .image import Image, ScalarImage, LabelMap
 from .inference import GridSampler, GridAggregator
 from .sampler import PatchSampler, LabelSampler, WeightedSampler, UniformSampler
 
+Image.__module__ = "torchio.data"
 
 __all__ = [
     'Queue',

--- a/torchio/data/dataset.py
+++ b/torchio/data/dataset.py
@@ -6,22 +6,24 @@ from torch.utils.data import Dataset
 
 from .subject import Subject
 
+Dataset.__module__ = "torch.utils.data"
+
 
 class SubjectsDataset(Dataset):
     """Base TorchIO dataset.
 
-    :class:`~torchio.data.dataset.SubjectsDataset`
+    :class:`~torchio.data.SubjectsDataset`
     is a reader of 3D medical images that directly
     inherits from :class:`torch.utils.data.Dataset`.
     It can be used with a :class:`torch.utils.data.DataLoader`
     for efficient loading and augmentation.
     It receives a list of instances of
-    :class:`torchio.data.subject.Subject`.
+    :class:`~torchio.data.Subject`.
 
     Args:
         subjects: List of instances of
-            :class:`~torchio.data.subject.Subject`.
-        transform: An instance of :class:`torchio.transforms.Transform`
+            :class:`~torchio.data.Subject`.
+        transform: An instance of :class:`~torchio.transforms.Transform`
             that will be applied to each subject.
 
     Example:
@@ -84,7 +86,7 @@ class SubjectsDataset(Dataset):
         """Set the :attr:`transform` attribute.
 
         Args:
-            transform: An instance of :class:`torchio.transforms.Transform`.
+            transform: An instance of :class:`~torchio.transforms.Transform`.
         """
         if transform is not None and not callable(transform):
             raise ValueError(

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -60,7 +60,7 @@ class Image(dict):
             all types, and nearest neighbor interpolation is always used to
             resample images with type :attr:`torchio.LABEL`.
             The type :attr:`torchio.SAMPLING_MAP` may be used with instances of
-            :class:`~torchio.data.sampler.weighted.WeightedSampler`.
+            :class:`~torchio.data.WeightedSampler`.
         tensor: If :attr:`path` is not given, :attr:`tensor` must be a 4D
             :class:`torch.Tensor` or NumPy array with dimensions
             :math:`(C, W, H, D)`.
@@ -495,7 +495,7 @@ class ScalarImage(Image):
         >>> type(image.data)
         torch.Tensor
 
-    See :class:`~torchio.data.image.Image` for more information.
+    See :class:`~torchio.data.Image` for more information.
     """
     def __init__(self, *args, **kwargs):
         if 'type' in kwargs and kwargs['type'] != INTENSITY:
@@ -520,7 +520,7 @@ class LabelMap(Image):
         ...     'csf.nii.gz',
         ... )
 
-    See :class:`~torchio.data.image.Image` for more information.
+    See :class:`~torchio.data.Image` for more information.
     """
     def __init__(self, *args, **kwargs):
         if 'type' in kwargs and kwargs['type'] != LABEL:

--- a/torchio/data/inference/grid_sampler.py
+++ b/torchio/data/inference/grid_sampler.py
@@ -8,6 +8,8 @@ from ...torchio import LOCATION, TypeTuple, TypeTripletInt
 from ..subject import Subject
 from ..sampler.sampler import PatchSampler
 
+PatchSampler.__module__ = 'torchio.data'
+
 
 class GridSampler(PatchSampler, Dataset):
     r"""Extract patches across a whole volume.
@@ -16,7 +18,7 @@ class GridSampler(PatchSampler, Dataset):
     volume. It is often used with a :class:`~torchio.data.GridAggregator`.
 
     Args:
-        subject: Instance of :class:`~torchio.data.subject.Subject`
+        subject: Instance of :class:`~torchio.data.Subject`
             from which patches will be extracted.
         patch_size: Tuple of integers :math:`(w, h, d)` to generate patches
             of size :math:`w \times h \times d`.

--- a/torchio/data/queue.py
+++ b/torchio/data/queue.py
@@ -10,13 +10,15 @@ from .subject import Subject
 from .sampler import PatchSampler
 from .dataset import SubjectsDataset
 
+Dataset.__module__ = 'torch.utils.data'
+
 
 class Queue(Dataset):
     r"""Patches queue used for patch-based training.
 
     Args:
         subjects_dataset: Instance of
-            :class:`~torchio.data.dataset.SubjectsDataset`.
+            :class:`~torchio.data.SubjectsDataset`.
         max_length: Maximum number of patches that can be stored in the queue.
             Using a large number means that the queue needs to be filled less
             often, but more CPU memory is needed to store the patches.

--- a/torchio/datasets/ixi.py
+++ b/torchio/datasets/ixi.py
@@ -26,6 +26,8 @@ from ..utils import download_and_extract_archive
 from ..transforms import Transform
 from .. import SubjectsDataset, Subject, ScalarImage, LabelMap, TypePath
 
+SubjectsDataset.__module__ = 'torchio.data'
+
 
 class IXI(SubjectsDataset):
     """
@@ -34,7 +36,7 @@ class IXI(SubjectsDataset):
     Args:
         root: Root directory to which the dataset will be downloaded.
         transform: An instance of
-            :class:`~torchio.transforms.transform.Transform`.
+            :class:`~torchio.transforms.Transform`.
         download: If set to ``True``, will download the data into :attr:`root`.
         modalities: List of modalities to be downloaded. They must be in
             ``('T1', 'T2', 'PD', 'MRA', 'DTI')``.
@@ -173,7 +175,7 @@ class IXITiny(SubjectsDataset):
     Args:
         root: Root directory to which the dataset will be downloaded.
         transform: An instance of
-            :class:`~torchio.transforms.transform.Transform`.
+            :class:`~torchio.transforms.Transform`.
         download: If set to ``True``, will download the data into :attr:`root`.
 
     .. _notebook: https://github.com/fepegar/torchio/blob/master/examples/README.md

--- a/torchio/datasets/slicer.py
+++ b/torchio/datasets/slicer.py
@@ -3,6 +3,8 @@ from ..utils import download_url
 from .. import Subject, ScalarImage
 from ..utils import get_torchio_cache_dir
 
+Subject.__module__ = 'torchio.data'
+
 
 SLICER_URL = 'https://github.com/Slicer/SlicerTestingData/releases/download/'
 URLS_DICT = {

--- a/torchio/transforms/augmentation/composition.py
+++ b/torchio/transforms/augmentation/composition.py
@@ -10,6 +10,8 @@ from .. import Transform
 from . import RandomTransform
 
 
+RandomTransform.__module__ = 'torchio.transforms.augmentation'
+
 TypeTransformsDict = Union[Dict[Transform, float], Sequence[Transform]]
 
 
@@ -18,7 +20,7 @@ class Compose(Transform):
 
     Args:
         transforms: Sequence of instances of
-            :class:`~torchio.transforms.transform.Transform`.
+            :class:`~torchio.transforms.Transform`.
         p: Probability that this transform will be applied.
 
     .. note::
@@ -70,7 +72,7 @@ class OneOf(RandomTransform):
 
     Args:
         transforms: Dictionary with instances of
-            :class:`~torchio.transforms.transform.Transform` as keys and
+            :class:`~torchio.transforms.Transform` as keys and
             probabilities as values. Probabilities are normalized so they sum
             to one. If a sequence is given, the same probability will be
             assigned to each transform.

--- a/torchio/transforms/augmentation/intensity/random_gamma.py
+++ b/torchio/transforms/augmentation/intensity/random_gamma.py
@@ -84,7 +84,7 @@ class Gamma(IntensityTransform):
         If negative values are found in the input image :math:`I`,
         the applied transform is :math:`\text{sign}(I) |I|^\gamma`,
         instead of the usual :math:`I^\gamma`. The
-        :class:`~torchio.transforms.preprocessing.intensity.rescale.RescaleIntensity`
+        :class:`~torchio.transforms.RescaleIntensity`
         transform may be used to ensure that all values are positive.
 
     Example:

--- a/torchio/transforms/augmentation/intensity/random_ghosting.py
+++ b/torchio/transforms/augmentation/intensity/random_ghosting.py
@@ -29,7 +29,7 @@ class RandomGhosting(RandomTransform, IntensityTransform):
         axes: Axis along which the ghosts will be created. If
             :attr:`axes` is a tuple, the axis will be randomly chosen
             from the passed values. Anatomical labels may also be used (see
-            :class:`~torchio.transforms.augmentation.RandomFlip`).
+            :class:`~torchio.transforms.RandomFlip`).
         intensity: Positive number representing the artifact strength
             :math:`s` with respect to the maximum of the :math:`k`-space.
             If ``0``, the ghosts will not be visible. If a tuple

--- a/torchio/transforms/augmentation/intensity/random_labels_to_image.py
+++ b/torchio/transforms/augmentation/intensity/random_labels_to_image.py
@@ -63,7 +63,7 @@ class RandomLabelsToImage(RandomTransform, IntensityTransform):
 
     .. note:: It is recommended to blur the new images to make the result more
         realistic. See
-        :class:`~torchio.transforms.augmentation.RandomBlur`.
+        :class:`~torchio.transforms.RandomBlur`.
 
     Example:
         >>> import torchio as tio

--- a/torchio/transforms/augmentation/random_transform.py
+++ b/torchio/transforms/augmentation/random_transform.py
@@ -9,6 +9,8 @@ import torch
 from ... import TypeRangeFloat
 from .. import Transform
 
+Transform.__module__ = 'torchio.transforms'
+
 
 class RandomTransform(Transform):
     """Base class for stochastic augmentation transforms.

--- a/torchio/transforms/augmentation/spatial/random_anisotropy.py
+++ b/torchio/transforms/augmentation/spatial/random_anisotropy.py
@@ -28,7 +28,7 @@ class RandomAnisotropy(RandomTransform):
             to its initial spacing. Downsampling is performed using nearest
             neighbor interpolation. See :ref:`Interpolation` for supported
             interpolation types.
-        scalars_only: Apply only to instances of :class:`torchio.ScalarImage`.
+        scalars_only: Apply only to instances of :class:`torchio.data.ScalarImage`.
         p: Probability that this transform will be applied.
         keys: See :class:`~torchio.transforms.Transform`.
 

--- a/torchio/transforms/lambda_transform.py
+++ b/torchio/transforms/lambda_transform.py
@@ -4,6 +4,8 @@ from ..data.subject import Subject
 from ..torchio import DATA, TYPE, TypeCallable
 from .transform import Transform
 
+Transform.__module__ = 'torchio.transforms'
+
 
 class Lambda(Transform):
     """Applies a user-defined function as transform.

--- a/torchio/transforms/preprocessing/intensity/histogram_standardization.py
+++ b/torchio/transforms/preprocessing/intensity/histogram_standardization.py
@@ -30,7 +30,7 @@ class HistogramStandardization(NormalizationTransform):
             NumPy arrays defining the landmarks after training with
             :meth:`torchio.transforms.HistogramStandardization.train`.
         masking_method: See
-            :class:`~torchio.transforms.preprocessing.normalization_transform.NormalizationTransform`.
+            :class:`~torchio.transforms.preprocessing.intensity.NormalizationTransform`.
         p: Probability that this transform will be applied.
 
     Example:

--- a/torchio/transforms/preprocessing/intensity/rescale.py
+++ b/torchio/transforms/preprocessing/intensity/rescale.py
@@ -8,6 +8,8 @@ from ....data.subject import Subject
 from ....torchio import DATA, TypeRangeFloat
 from .normalization_transform import NormalizationTransform, TypeMaskingMethod
 
+NormalizationTransform.__module__ = 'torchio.transforms.preprocessing.intensity'
+
 
 class RescaleIntensity(NormalizationTransform):
     """Rescale intensity values to a certain range.
@@ -23,7 +25,7 @@ class RescaleIntensity(NormalizationTransform):
             If only one value :math:`d` is provided,
             :math:`(n_{min}, n_{max}) = (0, d)`.
         masking_method: See
-            :class:`~torchio.transforms.preprocessing.normalization_transform.NormalizationTransform`.
+            :class:`~torchio.transforms.preprocessing.intensity.NormalizationTransform`.
         p: Probability that this transform will be applied.
         keys: See :class:`~torchio.transforms.Transform`.
 

--- a/torchio/transforms/preprocessing/intensity/z_normalization.py
+++ b/torchio/transforms/preprocessing/intensity/z_normalization.py
@@ -10,7 +10,7 @@ class ZNormalization(NormalizationTransform):
 
     Args:
         masking_method: See
-            :class:`~torchio.transforms.preprocessing.intensity.normalization_transform.NormalizationTransform`.
+            :class:`~torchio.transforms.preprocessing.intensity.NormalizationTransform`.
         p: Probability that this transform will be applied.
         keys: See :class:`~torchio.transforms.Transform`.
     """

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -29,7 +29,7 @@ class Resample(SpatialTransform):
             If a string or :class:`~pathlib.Path` is given,
             all images will be resampled using the image
             with that name as reference or found at the path.
-            An instance of :class:`torchio.Image` can also be passed.
+            An instance of :class:`~torchio.data.Image` can also be passed.
         pre_affine_name: Name of the *image key* (not subject key) storing an
             affine matrix that will be applied to the image header before
             resampling. If ``None``, the image is resampled with an identity
@@ -37,7 +37,7 @@ class Resample(SpatialTransform):
         image_interpolation: String that defines the interpolation technique.
             Supported interpolation techniques for resampling
             are ``'nearest'``, ``'linear'`` and ``'bspline'``.
-        scalars_only: Apply only to instances of :class:`torchio.ScalarImage`.
+        scalars_only: Apply only to instances of :class:`~torchio.data.ScalarImage`.
         p: Probability that this transform will be applied.
         keys: See :class:`~torchio.transforms.Transform`.
 

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -19,15 +19,15 @@ class Transform(ABC):
     """Abstract class for all TorchIO transforms.
 
     All subclasses should overwrite
-    :meth:`torchio.tranforms.Transform.apply_transform`,
+    :meth:`torchio.transforms.Transform.apply_transform`,
     which takes data, applies some transformation and returns the result.
 
     The input can be an instance of
-    :class:`torchio.Subject`,
-    :class:`torchio.Image`,
+    :class:`~torchio.data.Subject`,
+    :class:`~torchio.data.Image`,
     :class:`numpy.ndarray`,
     :class:`torch.Tensor`,
-    :class:`SimpleITK.image`,
+    :class:`SimpleITK.Image`,
     or a Python dictionary.
 
     Args:
@@ -53,13 +53,13 @@ class Transform(ABC):
         """Transform data and return a result of the same type.
 
         Args:
-            data: Instance of 1) :class:`~torchio.Subject`, 4D
+            data: Instance of :class:`~torchio.data.Subject`, 4D
                 :class:`torch.Tensor` or NumPy array with dimensions
                 :math:`(C, W, H, D)`, where :math:`C` is the number of channels
                 and :math:`W, H, D` are the spatial dimensions. If the input is
                 a tensor, the affine matrix will be set to identity. Other
                 valid input types are a SimpleITK image, a
-                :class:`torch.Image`, a NiBabel Nifti1 Image or a Python
+                :class:`~torchio.data.Image`, a NiBabel :class:`~nibabel.nifti1.Nifti1Image` or a Python
                 dictionary. The output type is the same as te input type.
         """
         if torch.rand(1).item() > self.probability:


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #247.

**Description**
As discussed in #247, I fixed links to classes throughout the docs. As you suggested, Sphinx has some issues regarding to namespaces and modules. I kept the `.. currentmodule::`, and as long as you specify the module in the doc file, e.g. `.. currentmodule:: torchio.data`, I think you should be able to refer to classes within this module in other doc files/docstrings in the form of ``:class:`torchio.data.ClassName` ``, at least I was able to.

The only problem major problem with Sphinx was that it shows Base class inheritance inconsistently. For instance, if you inherit `SubjectsDataset`, it will say that the Base class is `torchio.data.dataset.SubjectsDataset` instead of `torchio.data.SubjectsDataset`, breaking the link. To work around this, I have added in some files a `__module__` attribute to imported classes with incorrect paths, e.g. `SubjectsDataset.__module__ = "torch.utils.data"`. This fixes the Base class, but leaves slightly annoying line of code. I can get rid of those `__module__` assignments, but then links to Base classes won't work. (I'm sure that there is another way to do this but I can't figure it out)

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [x] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
