### PR TITLE
Implementation of include/exclude args

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,6 +54,7 @@ intersphinx_mapping = {
     'torch': ('https://pytorch.org/docs/master/', None),  # https://github.com/pytorch/fairseq/blob/adb5b9c71f7ef4fe2f258e0da102d819ab9920ef/docs/conf.py#L131
     'torchvision': ('https://pytorch.org/docs/master/', None),
     'nibabel': ('https://nipy.org/nibabel/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -193,6 +193,10 @@ class TestTransforms(TorchioTestCase):
         with self.assertRaises(ValueError):
             tio.RandomNoise(include=['t2'], exclude=['t1'])
 
+    def test_keys_deprecated(self):
+        with self.assertWarns(DeprecationWarning):
+            tio.RandomNoise(keys=['t2'])
+
 
 class TestTransform(TorchioTestCase):
 

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -190,9 +190,8 @@ class TestTransforms(TorchioTestCase):
         )
 
     def test_transforms_use_include_and_exclude(self):
-        transform = tio.RandomNoise(include=['t2'], exclude=['t1'])
         with self.assertRaises(ValueError):
-            transform(transform)
+            tio.RandomNoise(include=['t2'], exclude=['t1'])
 
 
 class TestTransform(TorchioTestCase):

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -155,6 +155,45 @@ class TestTransforms(TorchioTestCase):
                 f'Changes after {transform.name}'
             )
 
+    def test_transforms_use_include(self):
+        original_subject = copy.deepcopy(self.sample_subject)
+        transform = tio.RandomNoise(include=['t1'])
+        transformed = transform(self.sample_subject)
+
+        self.assertTensorNotEqual(
+            original_subject.t1.data,
+            transformed.t1.data,
+            f'Changes after {transform.name}'
+        )
+
+        self.assertTensorEqual(
+            original_subject.t2.data,
+            transformed.t2.data,
+            f'Changes after {transform.name}'
+        )
+
+    def test_transforms_use_exclude(self):
+        original_subject = copy.deepcopy(self.sample_subject)
+        transform = tio.RandomNoise(exclude=['t2'])
+        transformed = transform(self.sample_subject)
+
+        self.assertTensorNotEqual(
+            original_subject.t1.data,
+            transformed.t1.data,
+            f'Changes after {transform.name}'
+        )
+
+        self.assertTensorEqual(
+            original_subject.t2.data,
+            transformed.t2.data,
+            f'Changes after {transform.name}'
+        )
+
+    def test_transforms_use_include_and_exclude(self):
+        transform = tio.RandomNoise(include=['t2'], exclude=['t1'])
+        with self.assertRaises(ValueError):
+            transform(transform)
+
 
 class TestTransform(TorchioTestCase):
 

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -52,7 +52,7 @@ class TestTransforms(TorchioTestCase):
         return tio.Compose(transforms)
 
     def test_transforms_dict(self):
-        transform = tio.RandomNoise(keys=('t1', 't2'))
+        transform = tio.RandomNoise(include=('t1', 't2'))
         input_dict = {k: v.data for (k, v) in self.sample_subject.items()}
         transformed = transform(input_dict)
         self.assertIsInstance(transformed, dict)

--- a/torchio/data/subject.py
+++ b/torchio/data/subject.py
@@ -1,6 +1,6 @@
 import copy
 import pprint
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Optional, Sequence
 
 import numpy as np
 
@@ -173,18 +173,32 @@ class Subject(dict):
         self.check_consistent_spatial_shape()
         self.check_consistent_affine()
 
-    def get_images_dict(self, intensity_only=True) -> Dict[str, Image]:
+    def get_images_dict(
+            self,
+            intensity_only=True,
+            include: Optional[Sequence[str]] = None,
+            exclude: Optional[Sequence[str]] = None,
+            ) -> Dict[str, Image]:
         images = {}
         for image_name, image in self.items():
             if not isinstance(image, Image):
                 continue
             if intensity_only and not image[TYPE] == INTENSITY:
                 continue
+            if include is not None and image_name not in include:
+                continue
+            if exclude is not None and image_name in exclude:
+                continue
             images[image_name] = image
         return images
 
-    def get_images(self, intensity_only=True) -> List[Image]:
-        images_dict = self.get_images_dict(intensity_only=intensity_only)
+    def get_images(
+            self,
+            intensity_only=True,
+            include: Optional[Sequence[str]] = None,
+            exclude: Optional[Sequence[str]] = None,
+            ) -> List[Image]:
+        images_dict = self.get_images_dict(intensity_only=intensity_only, include=include, exclude=exclude)
         return list(images_dict.values())
 
     def get_first_image(self) -> Image:

--- a/torchio/torchio.py
+++ b/torchio/torchio.py
@@ -1,7 +1,7 @@
 """Main module."""
 
 from pathlib import Path
-from typing import Union, Tuple, Callable
+from typing import Union, Tuple, Callable, Optional, Sequence
 import torch
 import numpy as np
 
@@ -28,6 +28,7 @@ CHANNELS_DIMENSION = 1
 # For typing hints
 TypePath = Union[Path, str]
 TypeNumber = Union[int, float]
+TypeKeys = Optional[Sequence[str]]
 TypeData = Union[torch.Tensor, np.ndarray]
 TypeTripletInt = Tuple[int, int, int]
 TypeSextetInt = Tuple[int, int, int, int, int, int]

--- a/torchio/transforms/augmentation/intensity/random_bias_field.py
+++ b/torchio/transforms/augmentation/intensity/random_bias_field.py
@@ -52,7 +52,7 @@ class RandomBiasField(RandomTransform, IntensityTransform):
             )
             arguments['coefficients'][image_name] = coefficients
             arguments['order'][image_name] = self.order
-        transform = BiasField(**arguments)
+        transform = BiasField(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/intensity/random_blur.py
+++ b/torchio/transforms/augmentation/intensity/random_blur.py
@@ -42,7 +42,7 @@ class RandomBlur(RandomTransform, IntensityTransform):
         for name, image in self.get_images_dict(subject).items():
             stds = [self.get_params(self.std_ranges) for _ in image.data]
             arguments['std'][name] = stds
-        transform = Blur(**arguments)
+        transform = Blur(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/intensity/random_gamma.py
+++ b/torchio/transforms/augmentation/intensity/random_gamma.py
@@ -55,7 +55,7 @@ class RandomGamma(RandomTransform, IntensityTransform):
         for name, image in self.get_images_dict(subject).items():
             gammas = [self.get_params(self.log_gamma_range) for _ in image.data]
             arguments['gamma'][name] = gammas
-        transform = Gamma(**arguments)
+        transform = Gamma(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/intensity/random_ghosting.py
+++ b/torchio/transforms/augmentation/intensity/random_ghosting.py
@@ -84,7 +84,7 @@ class RandomGhosting(RandomTransform, IntensityTransform):
             arguments['axis'][name] = axis_param
             arguments['intensity'][name] = intensity_param
             arguments['restore'][name] = self.restore
-        transform = Ghosting(**arguments)
+        transform = Ghosting(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/intensity/random_labels_to_image.py
+++ b/torchio/transforms/augmentation/intensity/random_labels_to_image.py
@@ -176,14 +176,14 @@ class RandomLabelsToImage(RandomTransform, IntensityTransform):
             else:
                 raise RuntimeError(f'No label maps found in subject: {subject}')
 
-        arguments = dict(
-            label_key=self.label_key,
-            mean=[],
-            std=[],
-            image_key=self.image_key,
-            used_labels=self.used_labels,
-            discretize=self.discretize,
-        )
+        arguments = {
+            'label_key': self.label_key,
+            'mean': [],
+            'std': [],
+            'image_key': self.image_key,
+            'used_labels': self.used_labels,
+            'discretize': self.discretize,
+        }
 
         label_map = subject[self.label_key][DATA]
 
@@ -215,7 +215,7 @@ class RandomLabelsToImage(RandomTransform, IntensityTransform):
             arguments['mean'].append(mean)
             arguments['std'].append(std)
 
-        transform = LabelsToImage(**arguments)
+        transform = LabelsToImage(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/intensity/random_motion.py
+++ b/torchio/transforms/augmentation/intensity/random_motion.py
@@ -77,7 +77,7 @@ class RandomMotion(RandomTransform, IntensityTransform, FourierTransform):
             arguments['degrees'][name] = degrees_params
             arguments['translation'][name] = translation_params
             arguments['image_interpolation'][name] = self.image_interpolation
-        transform = Motion(**arguments)
+        transform = Motion(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/intensity/random_noise.py
+++ b/torchio/transforms/augmentation/intensity/random_noise.py
@@ -45,6 +45,8 @@ class RandomNoise(RandomTransform, IntensityTransform):
             arguments['mean'][image_name] = mean
             arguments['std'][image_name] = std
             arguments['seed'][image_name] = seed
+        arguments['include'] = self.include
+        arguments['exclude'] = self.exclude
         transform = Noise(**arguments)
         transformed = transform(subject)
         return transformed

--- a/torchio/transforms/augmentation/intensity/random_noise.py
+++ b/torchio/transforms/augmentation/intensity/random_noise.py
@@ -45,9 +45,7 @@ class RandomNoise(RandomTransform, IntensityTransform):
             arguments['mean'][image_name] = mean
             arguments['std'][image_name] = std
             arguments['seed'][image_name] = seed
-        arguments['include'] = self.include
-        arguments['exclude'] = self.exclude
-        transform = Noise(**arguments)
+        transform = Noise(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/intensity/random_spike.py
+++ b/torchio/transforms/augmentation/intensity/random_spike.py
@@ -58,7 +58,7 @@ class RandomSpike(RandomTransform, IntensityTransform, FourierTransform):
             )
             arguments['spikes_positions'][image_name] = spikes_positions_param
             arguments['intensity'][image_name] = intensity_param
-        transform = Spike(**arguments)
+        transform = Spike(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/intensity/random_swap.py
+++ b/torchio/transforms/augmentation/intensity/random_swap.py
@@ -85,7 +85,7 @@ class RandomSwap(RandomTransform, IntensityTransform):
             )
             arguments['locations'][name] = locations
             arguments['patch_size'][name] = self.patch_size
-        transform = Swap(**arguments)
+        transform = Swap(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/random_transform.py
+++ b/torchio/transforms/augmentation/random_transform.py
@@ -22,6 +22,11 @@ class RandomTransform(Transform):
             ):
         super().__init__(**kwargs)
 
+    def add_include_exclude(self, kwargs):
+        kwargs['include'] = self.include
+        kwargs['exclude'] = self.exclude
+        return kwargs
+
     def parse_degrees(
             self,
             degrees: TypeRangeFloat,

--- a/torchio/transforms/augmentation/spatial/random_affine.py
+++ b/torchio/transforms/augmentation/spatial/random_affine.py
@@ -151,7 +151,7 @@ class RandomAffine(RandomTransform, SpatialTransform):
             default_pad_value=self.default_pad_value,
             image_interpolation=self.image_interpolation,
         )
-        transform = Affine(**arguments)
+        transform = Affine(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/spatial/random_anisotropy.py
+++ b/torchio/transforms/augmentation/spatial/random_anisotropy.py
@@ -92,10 +92,15 @@ class RandomAnisotropy(RandomTransform):
         )
         target_spacing = list(subject.spacing)
         target_spacing[axis] *= downsampling
+
+        arguments = {
+            'image_interpolation': 'nearest',
+            'scalars_only': self.scalars_only,
+        }
+
         downsample = Resample(
             tuple(target_spacing),
-            image_interpolation='nearest',
-            scalars_only=self.scalars_only,
+            **self.add_include_exclude(arguments)
         )
         downsampled = downsample(subject)
         upsample = Resample(

--- a/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
+++ b/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
@@ -167,11 +167,14 @@ class RandomElasticDeformation(RandomTransform, SpatialTransform):
             self.max_displacement,
             self.num_locked_borders,
         )
-        transform = ElasticDeformation(
-            control_points,
-            self.max_displacement,
-            self.image_interpolation,
-        )
+
+        arguments = {
+            'control_points': control_points,
+            'max_displacement': self.max_displacement,
+            'image_interpolation': self.image_interpolation,
+        }
+
+        transform = ElasticDeformation(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/augmentation/spatial/random_flip.py
+++ b/torchio/transforms/augmentation/spatial/random_flip.py
@@ -50,7 +50,11 @@ class RandomFlip(RandomTransform, SpatialTransform):
             if i not in potential_axes:
                 axes_to_flip_hot[i] = False
         axes, = np.where(axes_to_flip_hot)
-        transform = Flip(axes=axes.tolist())
+
+        arguments = {
+            'axes': axes.tolist(),
+        }
+        transform = Flip(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed
 

--- a/torchio/transforms/data_parser.py
+++ b/torchio/transforms/data_parser.py
@@ -59,7 +59,7 @@ class DataParser:
         elif isinstance(self.data, dict):  # e.g. Eisen or MONAI dicts
             if self.keys is None:
                 message = (
-                    'If input is a dictionary, a value for "keys" must be'
+                    'If input is a dictionary, a value for "include" must be'
                     ' specified when instantiating the transform'
                 )
                 raise RuntimeError(message)

--- a/torchio/transforms/intensity_transform.py
+++ b/torchio/transforms/intensity_transform.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import Dict
 
 from .transform import Transform
 from ..data import Image
@@ -8,9 +8,6 @@ class IntensityTransform(Transform):
     """Transform that modifies voxel intensities only."""
     def get_images_dict(self, sample) -> Dict[str, Image]:
         return sample.get_images_dict(intensity_only=True, include=self.include, exclude=self.exclude)
-
-    def get_images(self, sample) -> List[Image]:
-        return sample.get_images(intensity_only=True, include=self.include, exclude=self.exclude)
 
     def arguments_are_dict(self) -> bool:
         """Check if main arguments are dict.

--- a/torchio/transforms/intensity_transform.py
+++ b/torchio/transforms/intensity_transform.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 from .transform import Transform
-from .. import Image
+from ..data import Image
 
 
 class IntensityTransform(Transform):

--- a/torchio/transforms/intensity_transform.py
+++ b/torchio/transforms/intensity_transform.py
@@ -1,11 +1,16 @@
+from typing import List, Dict
+
 from .transform import Transform
+from .. import Image
 
 
 class IntensityTransform(Transform):
     """Transform that modifies voxel intensities only."""
-    @staticmethod
-    def get_images_dict(sample):
-        return sample.get_images_dict(intensity_only=True)
+    def get_images_dict(self, sample) -> Dict[str, Image]:
+        return sample.get_images_dict(intensity_only=True, include=self.include, exclude=self.exclude)
+
+    def get_images(self, sample) -> List[Image]:
+        return sample.get_images(intensity_only=True, include=self.include, exclude=self.exclude)
 
     def arguments_are_dict(self) -> bool:
         """Check if main arguments are dict.

--- a/torchio/transforms/lambda_transform.py
+++ b/torchio/transforms/lambda_transform.py
@@ -36,7 +36,7 @@ class Lambda(Transform):
         self.args_names = 'function', 'types_to_apply'
 
     def apply_transform(self, subject: Subject) -> Subject:
-        for image in subject.get_images(intensity_only=False):
+        for image in subject.get_images(intensity_only=False, include=self.include, exclude=self.exclude):
 
             image_type = image[TYPE]
             if self.types_to_apply is not None:

--- a/torchio/transforms/spatial_transform.py
+++ b/torchio/transforms/spatial_transform.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import List
 
 from .transform import Transform
 from ..data import Image
@@ -6,9 +6,6 @@ from ..data import Image
 
 class SpatialTransform(Transform):
     """Transform that modifies image bounds or voxels positions."""
-
-    def get_images_dict(self, sample) -> Dict[str, Image]:
-        return sample.get_images_dict(intensity_only=False, include=self.include, exclude=self.exclude)
 
     def get_images(self, sample) -> List[Image]:
         return sample.get_images(intensity_only=False, include=self.include, exclude=self.exclude)

--- a/torchio/transforms/spatial_transform.py
+++ b/torchio/transforms/spatial_transform.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 from .transform import Transform
-from .. import Image
+from ..data import Image
 
 
 class SpatialTransform(Transform):

--- a/torchio/transforms/spatial_transform.py
+++ b/torchio/transforms/spatial_transform.py
@@ -1,12 +1,14 @@
+from typing import Dict, List
+
 from .transform import Transform
+from .. import Image
 
 
 class SpatialTransform(Transform):
     """Transform that modifies image bounds or voxels positions."""
-    @staticmethod
-    def get_images(sample):
-        return sample.get_images(intensity_only=False)
 
-    @staticmethod
-    def get_images_dict(sample):
-        return sample.get_images_dict(intensity_only=False)
+    def get_images_dict(self, sample) -> Dict[str, Image]:
+        return sample.get_images_dict(intensity_only=False, include=self.include, exclude=self.exclude)
+
+    def get_images(self, sample) -> List[Image]:
+        return sample.get_images(intensity_only=False, include=self.include, exclude=self.exclude)

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -33,18 +33,20 @@ class Transform(ABC):
     Args:
         p: Probability that this transform will be applied.
         copy: Make a shallow copy of the input before applying the transform.
-        keys: Mandatory if the input is a :class:`dict`. The transform will
+        include: The transform will
             be applied only to the data in each key.
+        exclude: The transform will not be applied to the data in each key
     """
     def __init__(
             self,
             p: float = 1,
             copy: bool = True,
-            keys: Optional[Sequence[str]] = None,
+            include: Optional[Sequence[str]] = None,
+            exclude: Optional[Sequence[str]] = None,
             ):
         self.probability = self.parse_probability(p)
         self.copy = copy
-        self.keys = keys
+        self.include, self.exclude = self.parse_include_and_exclude(include, exclude)
 
     def __call__(
             self,
@@ -269,6 +271,19 @@ class Transform(ABC):
             )
             raise ValueError(message)
         return probability
+
+    @staticmethod
+    def parse_include_and_exclude(
+            include: Optional[Sequence[str]] = None,
+            exclude: Optional[Sequence[str]] = None,
+            ) -> Tuple[Optional[Sequence[str]], Optional[Sequence[str]]]:
+        if include is not None and exclude is not None:
+            message = (
+                'Include and exclude cannot be specified both. To apply this transform'
+                ' only to specific images use or include or exclude'
+            )
+            raise ValueError(message)
+        return include, exclude
 
     @staticmethod
     def nib_to_sitk(data: TypeData, affine: TypeData) -> sitk.Image:

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -66,7 +66,7 @@ class Transform(ABC):
         """
         if torch.rand(1).item() > self.probability:
             return data
-        data_parser = DataParser(data, keys=self.keys)
+        data_parser = DataParser(data, keys=self.include)
         subject = data_parser.get_subject()
         if self.copy:
             subject = copy.copy(subject)
@@ -280,7 +280,7 @@ class Transform(ABC):
         if include is not None and exclude is not None:
             message = (
                 'Include and exclude cannot be specified both. To apply this transform'
-                ' only to specific images use or include or exclude'
+                ' only to specific images use or include or exclude.'
             )
             raise ValueError(message)
         return include, exclude

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -280,7 +280,7 @@ class Transform(ABC):
         if include is not None and exclude is not None:
             message = (
                 'Include and exclude cannot be specified both. To apply this transform'
-                ' only to specific images use or include or exclude.'
+                ' to specific images only use or include or exclude.'
             )
             raise ValueError(message)
         return include, exclude

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -1,15 +1,16 @@
 import copy
 import numbers
+import warnings
+from typing import Union, Tuple
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Optional, Union, Tuple, Sequence
 
 import torch
 import numpy as np
 import SimpleITK as sitk
 
 from ..data.subject import Subject
-from .. import TypeData, TypeNumber
+from .. import TypeData, TypeNumber, TypeKeys
 from ..utils import nib_to_sitk, sitk_to_nib, to_tuple
 from .interpolation import Interpolation, get_sitk_interpolator
 from .data_parser import DataParser, TypeTransformInput
@@ -18,8 +19,8 @@ from .data_parser import DataParser, TypeTransformInput
 class Transform(ABC):
     """Abstract class for all TorchIO transforms.
 
-    All subclasses should overwrite
-    :meth:`torchio.tranforms.Transform.apply_transform`,
+    All subclasses must overwrite
+    :meth:`Transform.apply_transform`,
     which takes data, applies some transformation and returns the result.
 
     The input can be an instance of
@@ -33,20 +34,37 @@ class Transform(ABC):
     Args:
         p: Probability that this transform will be applied.
         copy: Make a shallow copy of the input before applying the transform.
-        include: The transform will
-            be applied only to the data in each key.
-        exclude: The transform will not be applied to the data in each key
+        include: Sequence of strings with the names of the only images to which
+            the transform will be applied.
+            Mandatory if the input is a :class:`dict`.
+        exclude: Sequence of strings with the names of the images to which the
+            the transform will not be applied, apart from the ones that are
+            excluded because of the transform type.
+            For example, if a subject includes an MRI, a CT and a label map, and
+            the CT is added to the list of exclusions of an intensity transform
+            such as :class:`~torchio.transforms.RandomBlur`,
+            the transform will be only applied to the MRI, as the label map is
+            excluded by default by spatial transforms.
     """
     def __init__(
             self,
             p: float = 1,
             copy: bool = True,
-            include: Optional[Sequence[str]] = None,
-            exclude: Optional[Sequence[str]] = None,
+            include: TypeKeys = None,
+            exclude: TypeKeys = None,
+            keys: TypeKeys = None,
             ):
         self.probability = self.parse_probability(p)
         self.copy = copy
-        self.include, self.exclude = self.parse_include_and_exclude(include, exclude)
+        if keys is not None:
+            message = (
+                'The "keys" argument is deprecated and will be removed in the'
+                ' future. Use "include" instead.'
+            )
+            warnings.warn(message, DeprecationWarning)
+            include = keys
+        self.include, self.exclude = self.parse_include_and_exclude(
+            include, exclude)
 
     def __call__(
             self,
@@ -274,15 +292,11 @@ class Transform(ABC):
 
     @staticmethod
     def parse_include_and_exclude(
-            include: Optional[Sequence[str]] = None,
-            exclude: Optional[Sequence[str]] = None,
-            ) -> Tuple[Optional[Sequence[str]], Optional[Sequence[str]]]:
+            include: TypeKeys = None,
+            exclude: TypeKeys = None,
+            ) -> Tuple[TypeKeys, TypeKeys]:
         if include is not None and exclude is not None:
-            message = (
-                'Include and exclude cannot be specified both. To apply this transform'
-                ' to specific images only use or include or exclude.'
-            )
-            raise ValueError(message)
+            raise ValueError('Include and exclude cannot both be specified')
         return include, exclude
 
     @staticmethod


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #54 .

**Description**
This proposes the use of include and exclude args for transforms. In this way a transform can be applied to a subset of the images in a dictionary, needed when some image need other preprocessing/augmentation than others

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
