### PR TITLE
remove internal self.fill, and keep padding_mode as string or number

### DIFF
--- a/tests/transforms/preprocessing/test_pad.py
+++ b/tests/transforms/preprocessing/test_pad.py
@@ -1,6 +1,7 @@
+import torch
 import SimpleITK as sitk
+import torchio as tio
 from torchio.utils import sitk_to_nib
-from torchio.transforms import Pad
 from ...utils import TorchioTestCase
 
 
@@ -12,8 +13,13 @@ class TestPad(TorchioTestCase):
         sitk_image = image.as_sitk()
         low, high = padding[::2], padding[1::2]
         sitk_padded = sitk.ConstantPad(sitk_image, low, high, 0)
-        tio_padded = Pad(padding, padding_mode=0)(image)
+        tio_padded = tio.Pad(padding, padding_mode=0)(image)
         sitk_tensor, sitk_affine = sitk_to_nib(sitk_padded)
         tio_tensor, tio_affine = sitk_to_nib(tio_padded.as_sitk())
         self.assertTensorEqual(sitk_tensor, tio_tensor)
         self.assertTensorEqual(sitk_affine, tio_affine)
+
+    def test_nans_history(self):
+        padded = tio.Pad(1, padding_mode=2)(self.sample_subject)
+        again = padded.history[0](self.sample_subject)
+        assert not torch.isnan(again.t1.data).any()


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #376.

**Description**

I remove internal fill attribute, to keep padding_mode as given in input (a string, or a number for the constant mode)
parse_padding_mode was then only use to check padding_mode strings, I rename it to 
check_padding_mode

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [x] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
