### PR TITLE
Remove checks and casts to float32

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -9,9 +9,8 @@ import torch
 import numpy as np
 import nibabel as nib
 
-from torchio import ScalarImage, LabelMap, Subject, INTENSITY, LABEL, STEM
+import torchio as tio
 from ..utils import TorchioTestCase
-from torchio import RandomFlip, RandomAffine
 
 
 class TestImage(TorchioTestCase):
@@ -19,58 +18,50 @@ class TestImage(TorchioTestCase):
 
     def test_image_not_found(self):
         with self.assertRaises(FileNotFoundError):
-            ScalarImage('nopath')
+            tio.ScalarImage('nopath')
 
     def test_wrong_path_value(self):
         with self.assertRaises(RuntimeError):
-            ScalarImage('~&./@#"!?X7=+')
+            tio.ScalarImage('~&./@#"!?X7=+')
 
     def test_wrong_path_type(self):
         with self.assertRaises(TypeError):
-            ScalarImage(5)
+            tio.ScalarImage(5)
 
     def test_wrong_affine(self):
         with self.assertRaises(TypeError):
-            ScalarImage(5, affine=1)
+            tio.ScalarImage(5, affine=1)
 
     def test_tensor_flip(self):
         sample_input = torch.ones((4, 30, 30, 30))
-        RandomFlip()(sample_input)
+        tio.RandomFlip()(sample_input)
 
     def test_tensor_affine(self):
         sample_input = torch.ones((4, 10, 10, 10))
-        RandomAffine()(sample_input)
-
-    def test_scalar_image_type(self):
-        data = torch.ones((1, 10, 10, 10))
-        image = ScalarImage(tensor=data)
-        self.assertIs(image.type, INTENSITY)
-
-    def test_label_map_type(self):
-        data = torch.ones((1, 10, 10, 10))
-        label = LabelMap(tensor=data)
-        self.assertIs(label.type, LABEL)
+        tio.RandomAffine()(sample_input)
 
     def test_wrong_scalar_image_type(self):
         data = torch.ones((1, 10, 10, 10))
         with self.assertRaises(ValueError):
-            ScalarImage(tensor=data, type=LABEL)
+            tio.ScalarImage(tensor=data, type=tio.LABEL)
 
     def test_wrong_label_map_type(self):
         data = torch.ones((1, 10, 10, 10))
         with self.assertRaises(ValueError):
-            LabelMap(tensor=data, type=INTENSITY)
+            tio.LabelMap(tensor=data, type=tio.INTENSITY)
 
     def test_no_input(self):
         with self.assertRaises(ValueError):
-            ScalarImage()
+            tio.ScalarImage()
 
     def test_bad_key(self):
         with self.assertRaises(ValueError):
-            ScalarImage(path='', data=5)
+            tio.ScalarImage(path='', data=5)
 
     def test_repr(self):
-        subject = Subject(t1=ScalarImage(self.get_image_path('repr_test')))
+        subject = tio.Subject(
+            t1=tio.ScalarImage(self.get_image_path('repr_test')),
+        )
         assert 'shape' not in repr(subject['t1'])
         subject.load()
         assert 'shape' in repr(subject['t1'])
@@ -82,18 +73,18 @@ class TestImage(TorchioTestCase):
 
     def test_bad_affine(self):
         with self.assertRaises(ValueError):
-            ScalarImage(tensor=torch.rand(1, 2, 3, 4), affine=np.eye(3))
+            tio.ScalarImage(tensor=torch.rand(1, 2, 3, 4), affine=np.eye(3))
 
     def test_nans_tensor(self):
         tensor = np.random.rand(1, 2, 3, 4)
         tensor[0, 0, 0, 0] = np.nan
         with self.assertWarns(RuntimeWarning):
-            image = ScalarImage(tensor=tensor, check_nans=True)
+            image = tio.ScalarImage(tensor=tensor, check_nans=True)
         image.set_check_nans(False)
 
     def test_get_center(self):
         tensor = torch.rand(1, 3, 3, 3)
-        image = ScalarImage(tensor=tensor)
+        image = tio.ScalarImage(tensor=tensor)
         ras = image.get_center()
         lps = image.get_center(lps=True)
         self.assertEqual(ras, (1, 1, 1))
@@ -101,27 +92,27 @@ class TestImage(TorchioTestCase):
 
     def test_with_list_of_missing_files(self):
         with self.assertRaises(FileNotFoundError):
-            ScalarImage(path=['nopath', 'error'])
+            tio.ScalarImage(path=['nopath', 'error'])
 
     def test_with_a_list_of_paths(self):
         shape = (5, 5, 5)
         path1 = self.get_image_path('path1', shape=shape)
         path2 = self.get_image_path('path2', shape=shape)
-        image = ScalarImage(path=[path1, path2])
+        image = tio.ScalarImage(path=[path1, path2])
         self.assertEqual(image.shape, (2, 5, 5, 5))
-        self.assertEqual(image[STEM], ['path1', 'path2'])
+        self.assertEqual(image[tio.STEM], ['path1', 'path2'])
 
     def test_with_a_list_of_images_with_different_shapes(self):
         path1 = self.get_image_path('path1', shape=(5, 5, 5))
         path2 = self.get_image_path('path2', shape=(7, 5, 5))
-        image = ScalarImage(path=[path1, path2])
+        image = tio.ScalarImage(path=[path1, path2])
         with self.assertRaises(RuntimeError):
             image.load()
 
     def test_with_a_list_of_images_with_different_affines(self):
         path1 = self.get_image_path('path1', spacing=(1, 1, 1))
         path2 = self.get_image_path('path2', spacing=(1, 2, 1))
-        image = ScalarImage(path=[path1, path2])
+        image = tio.ScalarImage(path=[path1, path2])
         with self.assertWarns(RuntimeWarning):
             image.load()
 
@@ -130,13 +121,13 @@ class TestImage(TorchioTestCase):
         path1 = self.get_image_path('path1', shape=shape, suffix='.nii')
         path2 = self.get_image_path('path2', shape=shape, suffix='.img')
         path3 = self.get_image_path('path3', shape=shape, suffix='.hdr')
-        image = ScalarImage(path=[path1, path2, path3])
+        image = tio.ScalarImage(path=[path1, path2, path3])
         self.assertEqual(image.shape, (3, 5, 6, 1))
-        self.assertEqual(image[STEM], ['path1', 'path2', 'path3'])
+        self.assertEqual(image[tio.STEM], ['path1', 'path2', 'path3'])
 
     def test_axis_name_2d(self):
         path = self.get_image_path('im2d', shape=(5, 6))
-        image = ScalarImage(path)
+        image = tio.ScalarImage(path)
         height_idx = image.axis_name_to_index('t')
         width_idx = image.axis_name_to_index('l')
         self.assertEqual(image.height, image.shape[height_idx])
@@ -148,17 +139,17 @@ class TestImage(TorchioTestCase):
 
     def test_data_type_uint16_array(self):
         tensor = np.random.rand(1, 3, 3, 3).astype(np.uint16)
-        image = ScalarImage(tensor=tensor)
+        image = tio.ScalarImage(tensor=tensor)
         self.assertEqual(image.data.dtype, torch.int32)
 
     def test_data_type_uint32_array(self):
         tensor = np.random.rand(1, 3, 3, 3).astype(np.uint32)
-        image = ScalarImage(tensor=tensor)
+        image = tio.ScalarImage(tensor=tensor)
         self.assertEqual(image.data.dtype, torch.int64)
 
     def test_save_image_with_data_type_boolean(self):
         tensor = np.random.rand(1, 3, 3, 3).astype(np.bool)
-        image = ScalarImage(tensor=tensor)
+        image = tio.ScalarImage(tensor=tensor)
         image.save(self.dir / 'image.nii')
 
     def test_load_uint(self):
@@ -168,4 +159,4 @@ class TestImage(TorchioTestCase):
             img = nib.Nifti1Image(data, affine)
             with tempfile.NamedTemporaryFile(suffix='.nii') as f:
                 nib.save(img, f.name)
-                ScalarImage(f.name).load()
+                tio.ScalarImage(f.name).load()

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -3,8 +3,12 @@
 """Tests for Image."""
 
 import copy
+import tempfile
+
 import torch
 import numpy as np
+import nibabel as nib
+
 from torchio import ScalarImage, LabelMap, Subject, INTENSITY, LABEL, STEM
 from ..utils import TorchioTestCase
 from torchio import RandomFlip, RandomAffine
@@ -156,3 +160,12 @@ class TestImage(TorchioTestCase):
         tensor = np.random.rand(1, 3, 3, 3).astype(np.bool)
         image = ScalarImage(tensor=tensor)
         image.save(self.dir / 'image.nii')
+
+    def test_load_uint(self):
+        affine = np.eye(4)
+        for dtype in np.uint16, np.uint32:
+            data = np.ones((3, 3, 3), dtype=dtype)
+            img = nib.Nifti1Image(data, affine)
+            with tempfile.NamedTemporaryFile(suffix='.nii') as f:
+                nib.save(img, f.name)
+                ScalarImage(f.name).load()

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -151,3 +151,8 @@ class TestImage(TorchioTestCase):
         tensor = np.random.rand(1, 3, 3, 3).astype(np.uint32)
         image = ScalarImage(tensor=tensor)
         self.assertEqual(image.data.dtype, torch.int64)
+
+    def test_save_image_with_data_type_boolean(self):
+        tensor = np.random.rand(1, 3, 3, 3).astype(np.bool)
+        image = ScalarImage(tensor=tensor)
+        image.save(self.dir / 'image.nii')

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -141,3 +141,13 @@ class TestImage(TorchioTestCase):
     def test_plot(self):
         image = self.sample_subject.t1
         image.plot(show=False, output_path=self.dir / 'image.png')
+
+    def test_data_type_uint16_array(self):
+        tensor = np.random.rand(1, 3, 3, 3).astype(np.uint16)
+        image = ScalarImage(tensor=tensor)
+        self.assertEqual(image.data.dtype, torch.int32)
+
+    def test_data_type_uint32_array(self):
+        tensor = np.random.rand(1, 3, 3, 3).astype(np.uint32)
+        image = ScalarImage(tensor=tensor)
+        self.assertEqual(image.data.dtype, torch.int64)

--- a/tests/transforms/augmentation/test_random_elastic_deformation.py
+++ b/tests/transforms/augmentation/test_random_elastic_deformation.py
@@ -1,29 +1,9 @@
-import torch
 from torchio.transforms import RandomElasticDeformation
 from ...utils import TorchioTestCase
 
 
 class TestRandomElasticDeformation(TorchioTestCase):
     """Tests for `RandomElasticDeformation`."""
-
-    def test_random_elastic_deformation(self):
-        transform = RandomElasticDeformation(
-            num_control_points=5,
-            max_displacement=(2, 3, 5),  # half grid spacing is (3.3, 3.3, 5)
-        )
-        keys = ('t1', 't2', 'label')
-        fixtures = 2916.7192, 2955.1265, 2950
-        torch_rng_state = torch.random.get_rng_state()
-        torch.manual_seed(42)
-        transformed = transform(self.sample_subject)
-        torch.random.set_rng_state(torch_rng_state)
-        for key, fixture in zip(keys, fixtures):
-            sample_data = self.sample_subject[key].numpy()
-            transformed_data = transformed[key].numpy()
-            transformed_total = transformed_data.sum()
-            # Make sure that intensities have changed
-            self.assertTensorNotEqual(sample_data, transformed_data)
-            self.assertAlmostEqual(transformed_total, fixture, places=4)
 
     def test_inputs_pta_gt_one(self):
         with self.assertRaises(ValueError):

--- a/tests/transforms/augmentation/test_random_gamma.py
+++ b/tests/transforms/augmentation/test_random_gamma.py
@@ -5,28 +5,35 @@ from ...utils import TorchioTestCase
 
 class TestRandomGamma(TorchioTestCase):
     """Tests for `RandomGamma`."""
+    def get_random_tensor_zero_one(self):
+        return torch.rand(4, 5, 6, 7)
+
     def test_with_zero_gamma(self):
         transform = RandomGamma(log_gamma=0)
-        transformed = transform(self.sample_subject)
-        self.assertTensorAlmostEqual(self.sample_subject.t1.data, transformed.t1.data)
+        tensor = self.get_random_tensor_zero_one()
+        transformed = transform(tensor)
+        self.assertTensorAlmostEqual(tensor, transformed)
 
     def test_with_non_zero_gamma(self):
         transform = RandomGamma(log_gamma=(0.1, 0.3))
-        transformed = transform(self.sample_subject)
-        self.assertTensorNotEqual(self.sample_subject.t1.data, transformed.t1.data)
+        tensor = self.get_random_tensor_zero_one()
+        transformed = transform(tensor)
+        self.assertTensorNotEqual(tensor, transformed)
 
     def test_with_high_gamma(self):
         transform = RandomGamma(log_gamma=(100, 100))
-        transformed = transform(self.sample_subject)
+        tensor = self.get_random_tensor_zero_one()
+        transformed = transform(tensor)
         self.assertTensorAlmostEqual(
-            self.sample_subject.t1.data == 1, transformed.t1.data
+            tensor == 1, transformed
         )
 
     def test_with_low_gamma(self):
         transform = RandomGamma(log_gamma=(-100, -100))
-        transformed = transform(self.sample_subject)
+        tensor = self.get_random_tensor_zero_one()
+        transformed = transform(tensor)
         self.assertTensorAlmostEqual(
-            self.sample_subject.t1.data > 0, transformed.t1.data
+            tensor > 0, transformed
         )
 
     def test_wrong_gamma_type(self):

--- a/tests/transforms/preprocessing/test_crop_pad.py
+++ b/tests/transforms/preprocessing/test_crop_pad.py
@@ -22,9 +22,9 @@ class TestCropOrPad(TorchioTestCase):
         with self.assertWarns(RuntimeWarning):
             transformed = transform(self.sample_subject)
         for key in transformed:
-            image_dict = self.sample_subject[key]
-            self.assertTensorEqual(image_dict.data, transformed[key].data)
-            self.assertTensorEqual(image_dict.affine, transformed[key].affine)
+            image = self.sample_subject[key]
+            self.assertTensorEqual(image.data, transformed[key].data)
+            self.assertTensorEqual(image.affine, transformed[key].affine)
 
     def test_different_shape(self):
         shape = self.sample_subject['t1'].spatial_shape

--- a/tests/transforms/preprocessing/test_rescale.py
+++ b/tests/transforms/preprocessing/test_rescale.py
@@ -12,7 +12,11 @@ class TestRescaleIntensity(TorchioTestCase):
         transform = RescaleIntensity(out_min_max=(min_t1, max_t1))
         transformed = transform(self.sample_subject)
         assert np.allclose(
-            transformed.t1.data, self.sample_subject.t1.data, rtol=0, atol=1e-06)
+            transformed.t1.data,
+            self.sample_subject.t1.data,
+            rtol=0,
+            atol=1e-05,
+        )
 
     def test_min_max(self):
         transform = RescaleIntensity(out_min_max=(0., 1.))

--- a/tests/transforms/preprocessing/test_to_canonical.py
+++ b/tests/transforms/preprocessing/test_to_canonical.py
@@ -17,7 +17,7 @@ class TestToCanonical(TorchioTestCase):
         transform = ToCanonical()
         transformed = transform(self.sample_subject)
         self.assertEqual(transformed.t1.orientation, ('R', 'A', 'S'))
-        self.assertTensorEqual(
+        self.assertTensorAlmostEqual(
             transformed.t1.data,
             self.sample_subject.t1.data.numpy()[:, ::-1, :, :]
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -144,17 +144,28 @@ class TorchioTestCase(unittest.TestCase):
             data = (data > 0.5).astype(np.uint8)
             if not data.sum() and force_binary_foreground:
                 data[..., 0] = 1
+        elif self.flip_coin():  # cast some images
+            data *= 100
+            dtype = np.uint8 if self.flip_coin() else np.uint16
+            data = data.astype(dtype)
         if add_nans:
             data[:] = np.nan
         affine = np.diag((*spacing, 1))
         if suffix is None:
             suffix = random.choice(('.nii.gz', '.nii', '.nrrd', '.img', '.mnc'))
         path = self.dir / f'{stem}{suffix}'
-        if np.random.rand() > 0.5:
+        if self.flip_coin():
             path = str(path)
-        image = tio.ScalarImage(tensor=data, affine=affine, check_nans=not add_nans)
+        image = tio.ScalarImage(
+            tensor=data,
+            affine=affine,
+            check_nans=not add_nans,
+        )
         image.save(path)
         return path
+
+    def flip_coin(self):
+        return np.random.rand() > 0.5
 
     def get_tests_data_dir(self):
         return Path(__file__).parent / 'image_data'

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -378,6 +378,8 @@ class Image(dict):
             raise TypeError(message)
         if tensor.ndim != 4:
             raise ValueError('Input tensor must be 4D')
+        if tensor.dtype == torch.bool:
+            tensor = tensor.to(torch.uint8)
         if self.check_nans and torch.isnan(tensor).any():
             warnings.warn(f'NaNs found in tensor', RuntimeWarning)
         return tensor

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -364,7 +364,15 @@ class Image(dict):
             else:
                 raise RuntimeError('Input tensor cannot be None')
         if isinstance(tensor, np.ndarray):
-            tensor = torch.from_numpy(tensor)
+            try:
+                tensor = torch.from_numpy(tensor)
+            except TypeError:
+                if tensor.dtype == np.uint16:
+                    tensor = torch.from_numpy(tensor.astype(np.int32))
+                elif tensor.dtype == np.uint32:
+                    tensor = torch.from_numpy(tensor.astype(np.int64))
+                else:
+                    raise
         elif not isinstance(tensor, torch.Tensor):
             message = 'Input tensor must be a PyTorch tensor or NumPy array'
             raise TypeError(message)

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -149,7 +149,7 @@ class Image(dict):
             ])
         else:
             properties.append(f'path: "{self.path}"')
-        properties.append(f'type: {self.type}')
+        properties.append(f'dtype: {self.data.type()}')
         properties = '; '.join(properties)
         string = f'{self.__class__.__name__}({properties})'
         return string

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -364,10 +364,8 @@ class Image(dict):
             else:
                 raise RuntimeError('Input tensor cannot be None')
         if isinstance(tensor, np.ndarray):
-            tensor = torch.from_numpy(tensor.astype(np.float32))
-        elif isinstance(tensor, torch.Tensor):
-            tensor = tensor.float()
-        else:
+            tensor = torch.from_numpy(tensor)
+        elif not isinstance(tensor, torch.Tensor):
             message = 'Input tensor must be a PyTorch tensor or NumPy array'
             raise TypeError(message)
         if tensor.ndim != 4:

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -14,6 +14,7 @@ from ..utils import (
     get_rotation_and_spacing_from_affine,
     get_stem,
     ensure_4d,
+    check_uint_to_int,
 )
 from ..torchio import (
     TypeData,
@@ -364,15 +365,8 @@ class Image(dict):
             else:
                 raise RuntimeError('Input tensor cannot be None')
         if isinstance(tensor, np.ndarray):
-            try:
-                tensor = torch.from_numpy(tensor)
-            except TypeError:
-                if tensor.dtype == np.uint16:
-                    tensor = torch.from_numpy(tensor.astype(np.int32))
-                elif tensor.dtype == np.uint32:
-                    tensor = torch.from_numpy(tensor.astype(np.int64))
-                else:
-                    raise
+            tensor = check_uint_to_int(tensor)
+            tensor = torch.from_numpy(tensor)
         elif not isinstance(tensor, torch.Tensor):
             message = 'Input tensor must be a PyTorch tensor or NumPy array'
             raise TypeError(message)

--- a/torchio/data/io.py
+++ b/torchio/data/io.py
@@ -40,8 +40,7 @@ def _read_sitk(path: TypePath) -> Tuple[torch.Tensor, np.ndarray]:
     else:
         image = sitk.ReadImage(str(path))
     data, affine = sitk_to_nib(image, keepdim=True)
-    if data.dtype != np.float32:
-        data = data.astype(np.float32)
+
     tensor = torch.from_numpy(data)
     return tensor, affine
 

--- a/torchio/data/io.py
+++ b/torchio/data/io.py
@@ -6,7 +6,7 @@ import numpy as np
 import nibabel as nib
 import SimpleITK as sitk
 from .. import TypePath, TypeData
-from ..utils import nib_to_sitk, sitk_to_nib
+from ..utils import nib_to_sitk, sitk_to_nib, check_uint_to_int
 
 
 FLIPXY = np.diag([-1, -1, 1, 1])
@@ -29,6 +29,7 @@ def _read_nibabel(path: TypePath) -> Tuple[torch.Tensor, np.ndarray]:
     if data.ndim == 5:
         data = data[..., 0, :]
         data = data.transpose(3, 0, 1, 2)
+    data = check_uint_to_int(data)
     tensor = torch.from_numpy(data)
     affine = img.affine
     return tensor, affine
@@ -40,7 +41,7 @@ def _read_sitk(path: TypePath) -> Tuple[torch.Tensor, np.ndarray]:
     else:
         image = sitk.ReadImage(str(path))
     data, affine = sitk_to_nib(image, keepdim=True)
-
+    data = check_uint_to_int(data)
     tensor = torch.from_numpy(data)
     return tensor, affine
 

--- a/torchio/data/sampler/label.py
+++ b/torchio/data/sampler/label.py
@@ -73,6 +73,9 @@ class LabelSampler(WeightedSampler):
                 f' not found in subject subject: {subject}'
             )
             raise KeyError(message)
+
+        label_map_tensor = label_map_tensor.float()
+
         if self.label_probabilities_dict is None:
             return label_map_tensor > 0
         probability_map = self.get_probabilities_from_label_map(

--- a/torchio/transforms/augmentation/intensity/random_gamma.py
+++ b/torchio/transforms/augmentation/intensity/random_gamma.py
@@ -108,6 +108,7 @@ class Gamma(IntensityTransform):
                 gamma = self.gamma[name]
             gammas = to_tuple(gamma, length=len(image.data))
             transformed_tensors = []
+            image.data = image.data.float()
             for gamma, tensor in zip(gammas, image.data):
                 if self.invert_transform:
                     correction = power(tensor, 1 - gamma)

--- a/torchio/transforms/augmentation/intensity/random_labels_to_image.py
+++ b/torchio/transforms/augmentation/intensity/random_labels_to_image.py
@@ -189,7 +189,7 @@ class RandomLabelsToImage(RandomTransform, IntensityTransform):
 
         # Find out if we face a partial-volume image or a label map.
         # One-hot-encoded label map is considered as a partial-volume image
-        all_discrete = label_map.eq(label_map.round()).all()
+        all_discrete = label_map.eq(label_map.float().round()).all()
         same_num_dims = label_map.squeeze().dim() < label_map.dim()
         is_discretized = all_discrete and same_num_dims
 
@@ -306,7 +306,7 @@ class LabelsToImage(IntensityTransform):
 
         # Find out if we face a partial-volume image or a label map.
         # One-hot-encoded label map is considered as a partial-volume image
-        all_discrete = label_map.eq(label_map.round()).all()
+        all_discrete = label_map.eq(label_map.float().round()).all()
         same_num_dims = label_map.squeeze().dim() < label_map.dim()
         is_discretized = all_discrete and same_num_dims
 
@@ -352,7 +352,7 @@ class LabelsToImage(IntensityTransform):
                 bg_mask = label_map == -1
             else:
                 bg_mask = label_map.sum(dim=0, keepdim=True) < 0.5
-            final_image[DATA][bg_mask] = original_image[DATA][bg_mask]
+            final_image[DATA][bg_mask] = original_image[DATA][bg_mask].float()
 
         subject.add_image(final_image, self.image_key)
         return subject

--- a/torchio/transforms/lambda_transform.py
+++ b/torchio/transforms/lambda_transform.py
@@ -51,12 +51,6 @@ class Lambda(Transform):
                     f' of type {torch.Tensor}, not {type(result)}'
                 )
                 raise ValueError(message)
-            if result.dtype != torch.float32:
-                message = (
-                    'The data type of the returned value must be'
-                    f' of type {torch.float32}, not {result.dtype}'
-                )
-                raise ValueError(message)
             if result.ndim != function_arg.ndim:
                 message = (
                     'The number of dimensions of the returned value must'

--- a/torchio/transforms/preprocessing/intensity/histogram_standardization.py
+++ b/torchio/transforms/preprocessing/intensity/histogram_standardization.py
@@ -5,7 +5,7 @@ import torch
 import numpy as np
 from tqdm import tqdm
 
-from ....torchio import DATA, TypePath
+from ....torchio import TypePath
 from ....data.io import read_image
 from ....data.subject import Subject
 from .normalization_transform import NormalizationTransform, TypeMaskingMethod
@@ -86,10 +86,10 @@ class HistogramStandardization(NormalizationTransform):
                 f' landmarks dictionary, whose keys are {keys}'
             )
             raise KeyError(message)
-        image_dict = subject[image_name]
+        image = subject[image_name]
         landmarks = self.landmarks_dict[image_name]
-        image_dict.data = normalize(
-            image_dict[DATA],
+        image.data = normalize(
+            image.data,
             landmarks,
             mask=mask,
         )

--- a/torchio/transforms/preprocessing/intensity/normalization_transform.py
+++ b/torchio/transforms/preprocessing/intensity/normalization_transform.py
@@ -1,7 +1,7 @@
 from typing import Union
 import torch
 from ....data.subject import Subject
-from ....torchio import DATA, TypeCallable
+from ....torchio import TypeCallable
 from ... import IntensityTransform
 
 
@@ -60,11 +60,11 @@ class NormalizationTransform(IntensityTransform):
         if self.mask_name is None:
             return self.masking_method(tensor)
         else:
-            return subject[self.mask_name][DATA].bool()
+            return subject[self.mask_name].data.bool()
 
     def apply_transform(self, subject: Subject) -> Subject:
-        for image_name, image_dict in self.get_images_dict(subject).items():
-            mask = self.get_mask(subject, image_dict[DATA])
+        for image_name, image in self.get_images_dict(subject).items():
+            mask = self.get_mask(subject, image.data)
             self.apply_normalization(subject, image_name, mask)
         return subject
 

--- a/torchio/transforms/preprocessing/intensity/rescale.py
+++ b/torchio/transforms/preprocessing/intensity/rescale.py
@@ -4,7 +4,7 @@ import torch
 import numpy as np
 
 from ....data.subject import Subject
-from ....torchio import DATA, TypeRangeFloat
+from ....torchio import TypeRangeFloat
 from .normalization_transform import NormalizationTransform, TypeMaskingMethod
 
 
@@ -49,8 +49,8 @@ class RescaleIntensity(NormalizationTransform):
             image_name: str,
             mask: torch.Tensor,
             ) -> None:
-        image_dict = subject[image_name]
-        image_dict.data = self.rescale(image_dict[DATA], mask, image_name)
+        image = subject[image_name]
+        image.data = self.rescale(image.data, mask, image_name)
 
     def rescale(
             self,

--- a/torchio/transforms/preprocessing/intensity/rescale.py
+++ b/torchio/transforms/preprocessing/intensity/rescale.py
@@ -58,7 +58,8 @@ class RescaleIntensity(NormalizationTransform):
             mask: torch.Tensor,
             image_name: str,
             ) -> torch.Tensor:
-        array = tensor.clone().numpy()  # we'll use in-place operations later
+        # The tensor is cloned as in-place operations will be used
+        array = tensor.clone().float().numpy()
         mask = mask.numpy()
         values = array[mask]
         cutoff = np.percentile(values, self.percentiles)

--- a/torchio/transforms/preprocessing/intensity/z_normalization.py
+++ b/torchio/transforms/preprocessing/intensity/z_normalization.py
@@ -1,6 +1,5 @@
 import torch
 from ....data.subject import Subject
-from ....torchio import DATA
 from .normalization_transform import NormalizationTransform, TypeMaskingMethod
 
 
@@ -28,7 +27,7 @@ class ZNormalization(NormalizationTransform):
             ) -> None:
         image = subject[image_name]
         standardized = self.znorm(
-            image[DATA],
+            image.data,
             mask,
         )
         if standardized is None:
@@ -41,7 +40,7 @@ class ZNormalization(NormalizationTransform):
 
     @staticmethod
     def znorm(tensor: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
-        tensor = tensor.clone()
+        tensor = tensor.clone().float()
         values = tensor.masked_select(mask)
         mean, std = values.mean(), values.std()
         if std == 0:

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -111,15 +111,15 @@ class Resample(SpatialTransform):
         return result
 
     @staticmethod
-    def check_affine(affine_name: str, image_dict: dict):
+    def check_affine(affine_name: str, image: Image):
         if not isinstance(affine_name, str):
             message = (
                 'Affine name argument must be a string,'
                 f' not {type(affine_name)}'
             )
             raise TypeError(message)
-        if affine_name in image_dict:
-            matrix = image_dict[affine_name]
+        if affine_name in image:
+            matrix = image[affine_name]
             if not isinstance(matrix, (np.ndarray, torch.Tensor)):
                 message = (
                     'The affine matrix must be a NumPy array or PyTorch tensor,'
@@ -135,8 +135,8 @@ class Resample(SpatialTransform):
 
     @staticmethod
     def check_affine_key_presence(affine_name: str, subject: Subject):
-        for image_dict in subject.get_images(intensity_only=False):
-            if affine_name in image_dict:
+        for image in subject.get_images(intensity_only=False):
+            if affine_name in image:
                 return
         message = (
             f'An affine name was given ("{affine_name}"), but it was not found'

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -94,8 +94,6 @@ class Transform(ABC):
         for image in transformed.get_images(intensity_only=False):
             ndim = image.data.ndim
             assert ndim == 4, f'Output of {self.name} is {ndim}D'
-            dtype = image.data.dtype
-            assert dtype is torch.float32, f'Output of {self.name} is {dtype}'
 
         output = data_parser.get_output(transformed)
         return output

--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -415,3 +415,12 @@ def download_url(
         # check integrity of downloaded file
         if not check_integrity(fpath, md5):
             raise RuntimeError('File not found or corrupted.')
+
+
+def check_uint_to_int(array):
+    # This is because PyTorch won't take uint16 nor uint32
+    if array.dtype == np.uint16:
+        return array.astype(np.int32)
+    if array.dtype == np.uint32:
+        return array.astype(np.int64)
+    return array


### PR DESCRIPTION
Fixes #375 .

**Description**
Remove of the casts and checks for float32 to allow other datatypes (uint8 for label masks for example)

**Checklist**

- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
