### PR TITLE
Fix conversion to Pillow image

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -160,3 +160,17 @@ class TestImage(TorchioTestCase):
             with tempfile.NamedTemporaryFile(suffix='.nii') as f:
                 nib.save(img, f.name)
                 tio.ScalarImage(f.name).load()
+
+    def test_pil_3d(self):
+        with self.assertRaises(RuntimeError):
+            tio.ScalarImage(tensor=torch.rand(1, 2, 3, 4)).as_pil()
+
+    def test_pil_1(self):
+        tio.ScalarImage(tensor=torch.rand(1, 2, 3, 1)).as_pil()
+
+    def test_pil_2(self):
+        with self.assertRaises(RuntimeError):
+            tio.ScalarImage(tensor=torch.rand(2, 2, 3, 1)).as_pil()
+
+    def test_pil_3(self):
+        tio.ScalarImage(tensor=torch.rand(3, 2, 3, 1)).as_pil()


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #383.

**Description**
Conversion of 2D images to Pillow was not working because the original image path was being used. This is problematic because 1) the image might have been transformed and 2) sometimes images don't have a path, if a tensor is passed.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
