### PR TITLE
Print image path if probability map is empty

### DIFF
--- a/tests/data/sampler/test_label_sampler.py
+++ b/tests/data/sampler/test_label_sampler.py
@@ -1,6 +1,5 @@
 import torch
-import torchio
-from torchio.data import LabelSampler
+import torchio as tio
 from ...utils import TorchioTestCase
 
 
@@ -8,36 +7,36 @@ class TestLabelSampler(TorchioTestCase):
     """Tests for `LabelSampler` class."""
 
     def test_label_sampler(self):
-        sampler = LabelSampler(5)
+        sampler = tio.LabelSampler(5)
         for patch in sampler(self.sample_subject, num_patches=10):
-            patch_center = patch['label'][torchio.DATA][0, 2, 2, 2]
+            patch_center = patch['label'][tio.DATA][0, 2, 2, 2]
             self.assertEqual(patch_center, 1)
 
     def test_label_probabilities(self):
         labels = torch.Tensor((0, 0, 1, 1, 2, 1, 0)).reshape(1, 1, 1, -1)
-        subject = torchio.Subject(
-            label=torchio.Image(tensor=labels, type=torchio.LABEL),
+        subject = tio.Subject(
+            label=tio.Image(tensor=labels, type=tio.LABEL),
         )
-        subject = torchio.SubjectsDataset([subject])[0]
+        subject = tio.SubjectsDataset([subject])[0]
         probs_dict = {0: 0, 1: 50, 2: 25, 3: 25}
-        sampler = LabelSampler(5, 'label', label_probabilities=probs_dict)
+        sampler = tio.LabelSampler(5, 'label', label_probabilities=probs_dict)
         probabilities = sampler.get_probability_map(subject)
         fixture = torch.Tensor((0, 0, 2 / 12, 2 / 12, 3 / 12, 2 / 12, 0))
         assert torch.all(probabilities.squeeze().eq(fixture))
 
     def test_inconsistent_shape(self):
         # https://github.com/fepegar/torchio/issues/234#issuecomment-675029767
-        subject = torchio.Subject(
-            im1=torchio.ScalarImage(tensor=torch.rand(2, 4, 5, 6)),
-            im2=torchio.LabelMap(tensor=torch.rand(1, 4, 5, 6)),
+        subject = tio.Subject(
+            im1=tio.ScalarImage(tensor=torch.rand(2, 4, 5, 6)),
+            im2=tio.LabelMap(tensor=torch.rand(1, 4, 5, 6)),
         )
         patch_size = 2
-        sampler = LabelSampler(patch_size, 'im2')
+        sampler = tio.LabelSampler(patch_size, 'im2')
         next(sampler(subject))
 
     def test_multichannel_label_sampler(self):
-        subject = torchio.Subject(
-            label=torchio.LabelMap(
+        subject = tio.Subject(
+            label=tio.LabelMap(
                 tensor=torch.tensor(
                     [
                         [[[1, 1]]],
@@ -47,7 +46,7 @@ class TestLabelSampler(TorchioTestCase):
             )
         )
         patch_size = 1
-        sampler = LabelSampler(
+        sampler = tio.LabelSampler(
             patch_size,
             'label',
             label_probabilities={0: 1, 1: 1}


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #384.

**Description**
If the label image is not passed to the `LabelSampler` and the processed probability map is empty, a non-informative error message is shown. This PR adds a message with the problematic image path.


