### PR TITLE
Fix label sampler and improve error message

### DIFF
--- a/tests/data/sampler/test_label_sampler.py
+++ b/tests/data/sampler/test_label_sampler.py
@@ -64,3 +64,14 @@ class TestLabelSampler(TorchioTestCase):
         sampler = tio.LabelSampler(1)
         with self.assertRaises(RuntimeError):
             next(sampler(subject))
+
+    def test_empty_map(self):
+        # https://github.com/fepegar/torchio/issues/392
+        im = tio.ScalarImage(tensor=torch.rand(1, 6, 6, 6))
+        label = torch.zeros(1, 6, 6, 6)
+        label[..., 0] = 1  # voxels far from center
+        label_im = tio.LabelMap(tensor=label)
+        subject = tio.Subject(image=im, label=label_im)
+        sampler = tio.LabelSampler(4)
+        with self.assertRaises(RuntimeError):
+            next(sampler(subject))

--- a/tests/data/sampler/test_label_sampler.py
+++ b/tests/data/sampler/test_label_sampler.py
@@ -57,3 +57,10 @@ class TestLabelSampler(TorchioTestCase):
         probabilities = sampler.get_probability_map(subject)
         fixture = torch.Tensor((1 / 4, 3 / 4))
         assert torch.all(probabilities.squeeze().eq(fixture))
+
+    def test_no_labelmap(self):
+        im = tio.ScalarImage(tensor=torch.rand(1, 1, 1, 1))
+        subject = tio.Subject(image=im, no_label=im)
+        sampler = tio.LabelSampler(1)
+        with self.assertRaises(RuntimeError):
+            next(sampler(subject))

--- a/tests/data/sampler/test_weighted_sampler.py
+++ b/tests/data/sampler/test_weighted_sampler.py
@@ -24,7 +24,7 @@ class TestWeightedSampler(TorchioTestCase):
         subject = torchio.SubjectsDataset([subject])[0]
         return subject
 
-    def test_incosistent_shape(self):
+    def test_inconsistent_shape(self):
         # https://github.com/fepegar/torchio/issues/234#issuecomment-675029767
         subject = torchio.Subject(
             im1=torchio.ScalarImage(tensor=torch.rand(1, 4, 5, 6)),

--- a/torchio/data/sampler/label.py
+++ b/torchio/data/sampler/label.py
@@ -67,6 +67,13 @@ class LabelSampler(WeightedSampler):
                 if image[TYPE] == LABEL:
                     label_map = image
                     break
+            else:
+                images = subject.get_images(intensity_only=False)
+                message = (
+                    f'No label maps found in subject {subject} with image paths'
+                    f' {[image.path for image in images]}'
+                )
+                raise RuntimeError(message)
         elif self.probability_map_name in subject:
             label_map = subject[self.probability_map_name]
         else:

--- a/torchio/data/sampler/weighted.py
+++ b/torchio/data/sampler/weighted.py
@@ -109,9 +109,14 @@ class WeightedSampler(RandomSampler):
         self.clear_probability_borders(data, self.patch_size)
         total = data.sum()
         if total == 0:
+            half_patch_size = tuple(n // 2 for n in self.patch_size)
             message = (
                 'Empty probability map found:'
                 f' {self.get_probability_map_image(subject).path}'
+                '\nVoxels with positive probability might be near the image'
+                ' border.\nIf you suspect that this is the case, try adding a'
+                ' padding transform\nwith half the patch size:'
+                f' torchio.Pad({half_patch_size})'
             )
             raise RuntimeError(message)
         data /= total  # normalize probabilities


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Resolves #392.

**Description**
The label sampler failed if no label maps were found in the subject.
Also, if the cropped probability map is zero everywhere, the error message was not very helpful. Now, it suggests padding the images with half the patch size.
