### PR TITLE
Fix error with invertible custom transforms, also keep include/exclude lists for inverse transforms.

### DIFF
--- a/torchio/data/subject.py
+++ b/torchio/data/subject.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from ..constants import TYPE, INTENSITY
 from .image import Image
+from ..utils import get_subclasses
 
 
 class Subject(dict):
@@ -110,10 +111,12 @@ class Subject(dict):
 
     @property
     def history(self):
-        from .. import transforms
+        from ..transforms.transform import Transform
+        transform_classes = {cls.__name__: cls for cls in get_subclasses(Transform)}
+
         transforms_list = []
         for transform_name, arguments in self.applied_transforms:
-            transform = getattr(transforms, transform_name)(**arguments)
+            transform = transform_classes[transform_name](**arguments)
             transforms_list.append(transform)
         return transforms_list
 

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -311,7 +311,9 @@ class Transform(ABC):
         Return a dictionary with the arguments that would be necessary to
         reproduce the transform exactly.
         """
-        return {name: getattr(self, name) for name in self.args_names}
+        reproducing_arguments = dict(include=self.include, exclude=self.exclude, copy=self.copy)
+        reproducing_arguments.update({name: getattr(self, name) for name in self.args_names})
+        return reproducing_arguments
 
     def is_invertible(self):
         return hasattr(self, 'invert_transform')

--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -209,3 +209,9 @@ def history_collate(batch: Sequence, collate_transforms=True):
         if hasattr(first_element, attr):
             dictionary.update({attr: [getattr(d, attr) for d in batch]})
         return dictionary
+
+
+def get_subclasses(target_class: type) -> List[type]:
+    subclasses = target_class.__subclasses__()
+    subclasses += sum([get_subclasses(cls) for cls in subclasses], [])
+    return subclasses


### PR DESCRIPTION
**Description**
This fixes two bugs that I found when making a custom invertible `Transform`.

First is that `Subject.history` would not find any transforms defined outside torchio. To fix this I added a `get_subclasses(target_class)` function to `utils.py`.

Other thing I noticed was that `Transform._get_reproducing_arguments()` did not keep the include/exclude lists. So I added them there.

**Checklist**
<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [x] If the PR is ready and there are multiple commits, I have attempted to [squash them and force-push](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
