### PR TITLE
New label transformations

### DIFF
--- a/docs/source/transforms/preprocessing.rst
+++ b/docs/source/transforms/preprocessing.rst
@@ -85,3 +85,29 @@ Spatial
 
 .. autoclass:: ToCanonical
     :show-inheritance:
+
+Label
+---------
+
+.. currentmodule:: torchio.transforms.preprocessing.label
+
+
+:class:`RemapLabels`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: RemapLabels
+    :show-inheritance:
+
+
+:class:`RemoveLabels`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: RemoveLabels
+    :show-inheritance:
+
+
+:class:`SequentialLabels`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: SequentialLabels
+    :show-inheritance:

--- a/tests/transforms/label/test_remap_labels.py
+++ b/tests/transforms/label/test_remap_labels.py
@@ -1,0 +1,17 @@
+from torchio.transforms import RemapLabels
+from ...utils import TorchioTestCase
+
+
+class TestRemapLabels(TorchioTestCase):
+    """Tests for `RemapLabels`."""
+    def test_remap(self):
+        remapping = {1: 2, 2: 1, 5: 10, 6: 11}
+        remap_labels = RemapLabels(remapping=remapping)
+
+        subject = self.get_subject_with_labels(labels=remapping.keys())
+        transformed = remap_labels(subject)
+        inverse_transformed = transformed.apply_inverse_transform()
+
+        self.assertEqual(self.get_unique_labels(subject.label), set(remapping.keys()))
+        self.assertEqual(self.get_unique_labels(transformed.label), set(remapping.values()))
+        self.assertEqual(self.get_unique_labels(inverse_transformed.label), set(remapping.keys()))

--- a/tests/transforms/label/test_remove_labels.py
+++ b/tests/transforms/label/test_remove_labels.py
@@ -13,8 +13,16 @@ class TestRemoveLabels(TorchioTestCase):
 
         subject = self.get_subject_with_labels(labels=initial_labels)
         transformed = remove_labels(subject)
-        inverse_transformed = transformed.apply_inverse_transform()
-
-        self.assertEqual(self.get_unique_labels(subject.label), set(initial_labels))
-        self.assertEqual(self.get_unique_labels(transformed.label), set(remaining_labels))
-        self.assertEqual(self.get_unique_labels(inverse_transformed.label), set(remaining_labels))
+        inverse_transformed = transformed.apply_inverse_transform(warn=False)
+        self.assertEqual(
+            self.get_unique_labels(subject.label),
+            set(initial_labels),
+        )
+        self.assertEqual(
+            self.get_unique_labels(transformed.label),
+            set(remaining_labels),
+        )
+        self.assertEqual(
+            self.get_unique_labels(inverse_transformed.label),
+            set(remaining_labels),
+        )

--- a/tests/transforms/label/test_remove_labels.py
+++ b/tests/transforms/label/test_remove_labels.py
@@ -1,0 +1,20 @@
+from torchio.transforms import RemoveLabels
+from ...utils import TorchioTestCase
+
+
+class TestRemoveLabels(TorchioTestCase):
+    """Tests for `RemoveLabels`."""
+    def test_remove(self):
+        initial_labels = (1, 2, 3, 4, 5, 6, 7)
+        labels_to_remove = (1, 2, 5, 6)
+        remaining_labels = (3, 4, 7)
+
+        remove_labels = RemoveLabels(labels_to_remove)
+
+        subject = self.get_subject_with_labels(labels=initial_labels)
+        transformed = remove_labels(subject)
+        inverse_transformed = transformed.apply_inverse_transform()
+
+        self.assertEqual(self.get_unique_labels(subject.label), set(initial_labels))
+        self.assertEqual(self.get_unique_labels(transformed.label), set(remaining_labels))
+        self.assertEqual(self.get_unique_labels(inverse_transformed.label), set(remaining_labels))

--- a/tests/transforms/label/test_sequential_labels.py
+++ b/tests/transforms/label/test_sequential_labels.py
@@ -1,0 +1,19 @@
+from torchio.transforms import SequentialLabels
+from ...utils import TorchioTestCase
+
+
+class TestSequentialLabels(TorchioTestCase):
+    """Tests for `SequentialLabels`."""
+    def test_sequential(self):
+        initial_labels = (2, 8, 9, 10, 15, 20, 100)
+        transformed_labels = (1, 2, 3, 4, 5, 6, 7)
+
+        sequential_labels = SequentialLabels()
+
+        subject = self.get_subject_with_labels(labels=initial_labels)
+        transformed = sequential_labels(subject)
+        inverse_transformed = transformed.apply_inverse_transform()
+
+        self.assertEqual(self.get_unique_labels(subject.label), set(initial_labels))
+        self.assertEqual(self.get_unique_labels(transformed.label), set(transformed_labels))
+        self.assertEqual(self.get_unique_labels(inverse_transformed.label), set(initial_labels))

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -44,6 +44,9 @@ class TestTransforms(TorchioTestCase):
                 tio.RandomAffine(): 3,
                 elastic: 1,
             }),
+            tio.RemapLabels(remapping={1: 2, 2: 1, 3: 20, 4: 25}, masking_method='Left'),
+            tio.RemoveLabels([1, 3]),
+            tio.SequentialLabels(),
             tio.Pad(pad_args, padding_mode=3),
             tio.Crop(crop_args),
         ]
@@ -121,7 +124,7 @@ class TestTransforms(TorchioTestCase):
             transformed = transform(subject)
             trsf_channels = len(transformed.t1.data)
             assert trsf_channels > 1, f'Lost channels in {transform.name}'
-            if transform.name != 'RandomLabelsToImage':
+            if transform.name not in ['RandomLabelsToImage', 'RemapLabels', 'RemoveLabels', 'SequentialLabels']:
                 self.assertEqual(
                     subject.shape[0],
                     transformed.shape[0],

--- a/torchio/data/dataset.py
+++ b/torchio/data/dataset.py
@@ -97,10 +97,14 @@ class SubjectsDataset(Dataset):
 
     @staticmethod
     def _parse_subjects_list(subjects_list: Sequence[Subject]) -> None:
-        # Check that it's list or tuple
-        if not isinstance(subjects_list, collections.abc.Sequence):
-            raise TypeError(
-                f'Subject list must be a sequence, not {type(subjects_list)}')
+        # Check that it's an iterable
+        try:
+            iter(subjects_list)
+        except TypeError as e:
+            message = (
+                f'Subject list must be an iterable, not {type(subjects_list)}'
+            )
+            raise TypeError(message) from e
 
         # Check that it's not empty
         if not subjects_list:

--- a/torchio/data/subject.py
+++ b/torchio/data/subject.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from ..constants import TYPE, INTENSITY
 from .image import Image
+from ..utils import get_subclasses
 
 
 class Subject(dict):
@@ -110,10 +111,12 @@ class Subject(dict):
 
     @property
     def history(self):
-        from .. import transforms
+        from ..transforms.transform import Transform
+        transform_classes = {cls.__name__: cls for cls in get_subclasses(Transform)}
+
         transforms_list = []
         for transform_name, arguments in self.applied_transforms:
-            transform = getattr(transforms, transform_name)(**arguments)
+            transform = transform_classes[transform_name](**arguments)
             transforms_list.append(transform)
         return transforms_list
 

--- a/torchio/data/subject.py
+++ b/torchio/data/subject.py
@@ -128,7 +128,9 @@ class Subject(dict):
         return self.get_composed_history().inverse(warn=warn)
 
     def apply_inverse_transform(self, warn=True) -> 'Subject':
-        return self.get_inverse_transform(warn=warn)(self)
+        transformed = self.get_inverse_transform(warn=warn)(self)
+        transformed.clear_history()
+        return transformed
 
     def clear_history(self) -> None:
         self.applied_transforms = []

--- a/torchio/data/subject.py
+++ b/torchio/data/subject.py
@@ -121,11 +121,11 @@ class Subject(dict):
         from ..transforms.augmentation.composition import Compose
         return Compose(self.history)
 
-    def get_inverse_transform(self) -> 'Transform':
-        return self.get_composed_history().inverse()
+    def get_inverse_transform(self, warn=True) -> 'Transform':
+        return self.get_composed_history().inverse(warn=warn)
 
-    def apply_inverse_transform(self) -> 'Subject':
-        return self.get_inverse_transform()(self)
+    def apply_inverse_transform(self, warn=True) -> 'Subject':
+        return self.get_inverse_transform(warn=warn)(self)
 
     def clear_history(self) -> None:
         self.applied_transforms = []

--- a/torchio/transforms/__init__.py
+++ b/torchio/transforms/__init__.py
@@ -35,6 +35,9 @@ from .preprocessing import ZNormalization
 from .preprocessing import RescaleIntensity
 from .preprocessing import HistogramStandardization
 from .preprocessing.intensity.histogram_standardization import train as train_histogram
+from .preprocessing.label.remap_labels import RemapLabels
+from .preprocessing.label.sequential_labels import SequentialLabels
+from .preprocessing.label.remove_labels import RemoveLabels
 
 
 __all__ = [
@@ -79,4 +82,7 @@ __all__ = [
     'RescaleIntensity',
     'CropOrPad',
     'train_histogram',
+    'RemapLabels',
+    'SequentialLabels',
+    'RemoveLabels',
 ]

--- a/torchio/transforms/augmentation/composition.py
+++ b/torchio/transforms/augmentation/composition.py
@@ -69,7 +69,8 @@ class Compose(Transform):
             result = Compose(transforms)
         else:  # return noop if no invertible transforms are found
             def result(x): return x  # noqa: E704
-            warnings.warn('No invertible transforms found', RuntimeWarning)
+            if warn:
+                warnings.warn('No invertible transforms found', RuntimeWarning)
         return result
 
 

--- a/torchio/transforms/preprocessing/__init__.py
+++ b/torchio/transforms/preprocessing/__init__.py
@@ -8,6 +8,10 @@ from .intensity.rescale import RescaleIntensity
 from .intensity.z_normalization import ZNormalization
 from .intensity.histogram_standardization import HistogramStandardization
 
+from .label.remap_labels import RemapLabels
+from .label.sequential_labels import SequentialLabels
+from .label.remove_labels import RemoveLabels
+
 
 __all__ = [
     'Pad',
@@ -18,4 +22,7 @@ __all__ = [
     'RescaleIntensity',
     'ZNormalization',
     'HistogramStandardization',
+    'RemapLabels',
+    'SequentialLabels',
+    'RemoveLabels',
 ]

--- a/torchio/transforms/preprocessing/label/__init__.py
+++ b/torchio/transforms/preprocessing/label/__init__.py
@@ -1,0 +1,10 @@
+from .remap_labels import RemapLabels
+from .sequential_labels import SequentialLabels
+from .remove_labels import RemoveLabels
+
+
+__all__ = [
+    'RemapLabels',
+    'SequentialLabels',
+    'RemoveLabels',
+]

--- a/torchio/transforms/preprocessing/label/remap_labels.py
+++ b/torchio/transforms/preprocessing/label/remap_labels.py
@@ -1,0 +1,77 @@
+from ...transform import Transform, TypeMaskingMethod
+from ....data import LabelMap
+from typing import Dict
+
+
+class RemapLabels(Transform):
+    r"""Remap the integer ids of labels in a LabelMap.
+
+    This transformation may not be invertible if two labels are combined by the remapping.
+    A masking method can be used to correctly split the label into two during the inverse transformation (see example).
+
+    Args:
+        remapping: Dict[int, int].
+            Dictionary that specifies how labels should be remapped.
+            The keys are the old label ids, and the corresponding values replace them.
+        masking_method: Defines a mask for where the label remapping is applied. It can be one of:
+
+            - ``None``: the mask image is all ones, i.e. all values in the image are used.
+
+            - A string: key to a :class:`torchio.LabelMap` in the subject which is used as a mask,
+              OR an anatomical label: ``'Left'``, ``'Right'``, ``'Anterior'``, ``'Posterior'``,
+              ``'Inferior'``, ``'Superior'`` which specifies a side of the mask volume to be ones.
+
+            - A function: the mask image is computed as a function of the intensity image.
+              The function must receive and return a :class:`torch.Tensor`
+
+        **kwargs: See :class:`~torchio.transforms.Transform` for additional keyword arguments.
+
+    Example:
+        >>> import torchio as tio
+        >>> # Target label map has the following labels:
+        >>> # {'left_ventricle': 1, 'right_ventricle': 2, 'left_caudate': 3, 'right_caudate': 4,
+        >>> #  'left_putamen': 5, 'right_putamen': 6, 'left_thalamus': 7, 'right_thalamus': 8}
+        >>> transform = tio.RemapLabels({2:1, 4:3, 6:5, 8:7})
+        >>> # Merge right side labels with left side labels
+        >>> transformed = transform(subject)
+        >>> # Undesired behavior: The inverse transform will remap ALL left side labels to right side labels
+        >>> # so the label map only has right side labels.
+        >>> inverse_transformed = transformed.apply_inverse_transform()
+        >>> # Here's the *right* way to do it with masking:
+        >>> transform = tio.RemapLabels({2:1, 4:3, 6:5, 8:7}, masking_method="Right")
+        >>> # Remap the labels on the right side only (no difference yet).
+        >>> transformed = transform(subject)
+        >>> # Apply the inverse on the right side only. The labels are correctly split into left/right.
+        >>> inverse_transformed = transformed.apply_inverse_transform()
+    """
+    def __init__(
+            self,
+            remapping: Dict[int, int],
+            masking_method: TypeMaskingMethod = None,
+            **kwargs
+            ):
+        super().__init__(**kwargs)
+        self.kwargs = kwargs
+        self.remapping = remapping
+        self.masking_method = masking_method
+        self.args_names = ('remapping', 'masking_method',)
+
+    def apply_transform(self, subject):
+        for image in subject.get_images(intensity_only=False, include=self.include, exclude=self.exclude):
+            if not isinstance(image, LabelMap):
+                continue
+
+            new_data = image.data.clone()
+            mask = Transform.get_mask(self.masking_method, subject, new_data)
+            for old_id, new_id in self.remapping.items():
+                new_data[mask & (image.data == old_id)] = new_id
+            image.data = new_data
+
+        return subject
+
+    def is_invertible(self):
+        return True
+
+    def inverse(self):
+        inverse_remapping = {v: k for k, v in self.remapping.items()}
+        return RemapLabels(inverse_remapping, masking_method=self.masking_method, **self.kwargs)

--- a/torchio/transforms/preprocessing/label/remap_labels.py
+++ b/torchio/transforms/preprocessing/label/remap_labels.py
@@ -1,18 +1,21 @@
-from ...transform import Transform, TypeMaskingMethod
-from ....data import LabelMap
 from typing import Dict
+
+from ....data import LabelMap
+from ...transform import Transform, TypeMaskingMethod
 
 
 class RemapLabels(Transform):
     r"""Remap the integer ids of labels in a LabelMap.
 
-    This transformation may not be invertible if two labels are combined by the remapping.
-    A masking method can be used to correctly split the label into two during the inverse transformation (see example).
+    This transformation may not be invertible if two labels are combined by the
+    remapping.
+    A masking method can be used to correctly split the label into two during
+    the `inverse transformation <invertibility>`_ (see example).
 
     Args:
-        remapping: Dict[int, int].
-            Dictionary that specifies how labels should be remapped.
-            The keys are the old label ids, and the corresponding values replace them.
+        remapping: Dictionary that specifies how labels should be remapped.
+            The keys are the old label ids, and the corresponding values replace
+            them.
         masking_method: Defines a mask for where the label remapping is applied. It can be one of:
 
             - ``None``: the mask image is all ones, i.e. all values in the image are used.
@@ -22,9 +25,10 @@ class RemapLabels(Transform):
               ``'Inferior'``, ``'Superior'`` which specifies a side of the mask volume to be ones.
 
             - A function: the mask image is computed as a function of the intensity image.
-              The function must receive and return a :class:`torch.Tensor`
+              The function must receive and return a :class:`torch.Tensor`.
 
-        **kwargs: See :class:`~torchio.transforms.Transform` for additional keyword arguments.
+        **kwargs: See :class:`~torchio.transforms.Transform` for additional
+            keyword arguments.
 
     Example:
         >>> import torchio as tio
@@ -57,7 +61,12 @@ class RemapLabels(Transform):
         self.args_names = ('remapping', 'masking_method',)
 
     def apply_transform(self, subject):
-        for image in subject.get_images(intensity_only=False, include=self.include, exclude=self.exclude):
+        images = subject.get_images(
+            intensity_only=False,
+            include=self.include,
+            exclude=self.exclude,
+        )
+        for image in images:
             if not isinstance(image, LabelMap):
                 continue
 
@@ -74,4 +83,9 @@ class RemapLabels(Transform):
 
     def inverse(self):
         inverse_remapping = {v: k for k, v in self.remapping.items()}
-        return RemapLabels(inverse_remapping, masking_method=self.masking_method, **self.kwargs)
+        inverse_transform = RemapLabels(
+            inverse_remapping,
+            masking_method=self.masking_method,
+            **self.kwargs,
+        )
+        return inverse_transform

--- a/torchio/transforms/preprocessing/label/remove_labels.py
+++ b/torchio/transforms/preprocessing/label/remove_labels.py
@@ -1,22 +1,21 @@
 from typing import Sequence
 
-from .remap_labels import RemapLabels
 from ...transform import TypeMaskingMethod
+from .remap_labels import RemapLabels
 
 
 class RemoveLabels(RemapLabels):
-    r"""Removes labels from a label map by remapping them to the background label.
+    r"""Remove labels from a label map by remapping them to the background label.
 
-    This transformation is not invertible.
+    This transformation is not `invertible <invertibility>`_.
 
     Args:
         labels: A sequence of label integers that will be removed.
-
-        background_label: integer that specifies which label is considered to be background (generally 0)
-
-        masking_method: See
-            :class:`~torchio.RemapLabels`.
-        **kwargs: See :class:`~torchio.transforms.Transform` for additional keyword arguments.
+        background_label: integer that specifies which label is considered to be
+            background (generally 0).
+        masking_method: See :class:`~torchio.RemapLabels`.
+        **kwargs: See :class:`~torchio.transforms.Transform` for additional
+            keyword arguments.
     """
     def __init__(
             self,

--- a/torchio/transforms/preprocessing/label/remove_labels.py
+++ b/torchio/transforms/preprocessing/label/remove_labels.py
@@ -1,0 +1,36 @@
+from typing import Sequence
+
+from .remap_labels import RemapLabels
+from ...transform import TypeMaskingMethod
+
+
+class RemoveLabels(RemapLabels):
+    r"""Removes labels from a label map by remapping them to the background label.
+
+    This transformation is not invertible.
+
+    Args:
+        labels: A sequence of label integers that will be removed.
+
+        background_label: integer that specifies which label is considered to be background (generally 0)
+
+        masking_method: See
+            :class:`~torchio.RemapLabels`.
+        **kwargs: See :class:`~torchio.transforms.Transform` for additional keyword arguments.
+    """
+    def __init__(
+            self,
+            labels: Sequence[int],
+            background_label: int = 0,
+            masking_method: TypeMaskingMethod = None,
+            **kwargs
+            ):
+        remapping = {label: background_label for label in labels}
+        super().__init__(remapping, masking_method, **kwargs)
+        self.labels = labels
+        self.background_label = background_label
+        self.masking_method = masking_method
+        self.args_names = ('labels', 'background_label', 'masking_method',)
+
+    def is_invertible(self):
+        return False

--- a/torchio/transforms/preprocessing/label/sequential_labels.py
+++ b/torchio/transforms/preprocessing/label/sequential_labels.py
@@ -1,0 +1,39 @@
+import torch
+
+from ...transform import Transform, TypeMaskingMethod
+from ....data import LabelMap
+from .remap_labels import RemapLabels
+
+
+class SequentialLabels(Transform):
+    r"""Remaps the integer ids of labels in a LabelMap to be in a sequential order.
+    For example, if a label map has 6 labels with the ids (3, 5, 9, 15, 16, 23) then this will apply
+    a :class:`~torchio.RemapLabels` transform with `remapping={3:1, 5:2, 9:3, 15:4, 16:5, 23:6}`.
+    This transformation is always fully invertible.
+
+    Args:
+        masking_method: See
+            :class:`~torchio.RemapLabels`.
+        **kwargs: See :class:`~torchio.transforms.Transform` for additional keyword arguments.
+    """
+    def __init__(
+            self,
+            masking_method: TypeMaskingMethod = None,
+            **kwargs
+            ):
+        super().__init__(**kwargs)
+        self.masking_method = masking_method
+        self.args_names = []
+
+    def apply_transform(self, subject):
+        images_dict = subject.get_images_dict(intensity_only=False, include=self.include, exclude=self.exclude)
+        for name, image in images_dict.items():
+            if not isinstance(image, LabelMap):
+                continue
+
+            unique_labels = torch.unique(image.data)
+            remapping = {unique_labels[i].item(): i for i in range(1, len(unique_labels))}
+            transform = RemapLabels(remapping=remapping, masking_method=self.masking_method, include=name)
+            subject = transform(subject)
+
+        return subject

--- a/torchio/transforms/preprocessing/label/sequential_labels.py
+++ b/torchio/transforms/preprocessing/label/sequential_labels.py
@@ -1,20 +1,23 @@
 import torch
 
-from ...transform import Transform, TypeMaskingMethod
 from ....data import LabelMap
+from ...transform import Transform, TypeMaskingMethod
 from .remap_labels import RemapLabels
 
 
 class SequentialLabels(Transform):
-    r"""Remaps the integer ids of labels in a LabelMap to be in a sequential order.
-    For example, if a label map has 6 labels with the ids (3, 5, 9, 15, 16, 23) then this will apply
-    a :class:`~torchio.RemapLabels` transform with `remapping={3:1, 5:2, 9:3, 15:4, 16:5, 23:6}`.
-    This transformation is always fully invertible.
+    r"""Remap the integer IDs of labels in a LabelMap to be sequential.
+
+    For example, if a label map has 6 labels with IDs (3, 5, 9, 15, 16, 23),
+    then this will apply a :class:`~torchio.RemapLabels` transform with
+    ``remapping={3: 1, 5: 2, 9: 3, 15: 4, 16: 5, 23: 6}``.
+    This transformation is always `fully invertible <invertibility>`_.
 
     Args:
         masking_method: See
             :class:`~torchio.RemapLabels`.
-        **kwargs: See :class:`~torchio.transforms.Transform` for additional keyword arguments.
+        **kwargs: See :class:`~torchio.transforms.Transform` for additional
+            keyword arguments.
     """
     def __init__(
             self,
@@ -26,14 +29,25 @@ class SequentialLabels(Transform):
         self.args_names = []
 
     def apply_transform(self, subject):
-        images_dict = subject.get_images_dict(intensity_only=False, include=self.include, exclude=self.exclude)
+        images_dict = subject.get_images_dict(
+            intensity_only=False,
+            include=self.include,
+            exclude=self.exclude,
+        )
         for name, image in images_dict.items():
             if not isinstance(image, LabelMap):
                 continue
 
             unique_labels = torch.unique(image.data)
-            remapping = {unique_labels[i].item(): i for i in range(1, len(unique_labels))}
-            transform = RemapLabels(remapping=remapping, masking_method=self.masking_method, include=name)
+            remapping = {
+                unique_labels[i].item(): i
+                for i in range(1, len(unique_labels))
+            }
+            transform = RemapLabels(
+                remapping=remapping,
+                masking_method=self.masking_method,
+                include=name,
+            )
             subject = transform(subject)
 
         return subject

--- a/torchio/transforms/preprocessing/spatial/bounds_transform.py
+++ b/torchio/transforms/preprocessing/spatial/bounds_transform.py
@@ -1,15 +1,5 @@
-from typing import Union, Tuple
-import numpy as np
-from ....typing import TypeTripletInt
+from ....transforms.transform import TypeBounds
 from ... import SpatialTransform
-
-
-TypeSixBounds = Tuple[int, int, int, int, int, int]
-TypeBounds = Union[
-    int,
-    TypeTripletInt,
-    TypeSixBounds,
-]
 
 
 class BoundsTransform(SpatialTransform):
@@ -30,32 +20,3 @@ class BoundsTransform(SpatialTransform):
 
     def is_invertible(self):
         return True
-
-    @staticmethod
-    def parse_bounds(bounds_parameters: TypeBounds) -> TypeSixBounds:
-        try:
-            bounds_parameters = tuple(bounds_parameters)
-        except TypeError:
-            bounds_parameters = (bounds_parameters,)
-
-        # Check that numbers are integers
-        for number in bounds_parameters:
-            if not isinstance(number, (int, np.integer)) or number < 0:
-                message = (
-                    'Bounds values must be integers greater or equal to zero,'
-                    f' not "{bounds_parameters}" of type {type(number)}'
-                )
-                raise ValueError(message)
-        bounds_parameters = tuple(int(n) for n in bounds_parameters)
-        bounds_parameters_length = len(bounds_parameters)
-        if bounds_parameters_length == 6:
-            return bounds_parameters
-        if bounds_parameters_length == 1:
-            return 6 * bounds_parameters
-        if bounds_parameters_length == 3:
-            return tuple(np.repeat(bounds_parameters, 2).tolist())
-        message = (
-            'Bounds parameter must be an integer or a tuple of'
-            f' 3 or 6 integers, not {bounds_parameters}'
-        )
-        raise ValueError(message)

--- a/torchio/transforms/preprocessing/spatial/crop_or_pad.py
+++ b/torchio/transforms/preprocessing/spatial/crop_or_pad.py
@@ -5,7 +5,8 @@ import numpy as np
 
 from .pad import Pad
 from .crop import Crop
-from .bounds_transform import BoundsTransform, TypeTripletInt, TypeSixBounds
+from .bounds_transform import BoundsTransform
+from ...transform import TypeTripletInt, TypeSixBounds
 from ....data.subject import Subject
 from ....utils import round_up
 

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -12,9 +12,18 @@ import SimpleITK as sitk
 from ..utils import to_tuple
 from ..data.subject import Subject
 from ..data.io import nib_to_sitk, sitk_to_nib
-from ..typing import TypeData, TypeNumber, TypeKeys
+from ..data.image import LabelMap
+from ..typing import TypeData, TypeNumber, TypeKeys, TypeCallable, TypeTripletInt
 from .interpolation import Interpolation, get_sitk_interpolator
 from .data_parser import DataParser, TypeTransformInput
+
+TypeSixBounds = Tuple[int, int, int, int, int, int]
+TypeBounds = Union[
+    int,
+    TypeTripletInt,
+    TypeSixBounds,
+]
+TypeMaskingMethod = Union[str, TypeCallable, TypeBounds, None]
 
 
 class Transform(ABC):
@@ -121,11 +130,13 @@ class Transform(ABC):
     def add_transform_to_subject_history(self, subject):
         from .augmentation import RandomTransform
         from . import Compose, OneOf, CropOrPad
+        from .preprocessing.label import SequentialLabels
         call_others = (
             RandomTransform,
             Compose,
             OneOf,
             CropOrPad,
+            SequentialLabels,
         )
         if not isinstance(self, call_others):
             subject.add_transform(self, self._get_reproducing_arguments())
@@ -311,7 +322,7 @@ class Transform(ABC):
         Return a dictionary with the arguments that would be necessary to
         reproduce the transform exactly.
         """
-        reproducing_arguments = dict(include=self.include, exclude=self.exclude, copy=self.copy)
+        reproducing_arguments = {'include': self.include, 'exclude': self.exclude, 'copy': self.copy}
         reproducing_arguments.update({name: getattr(self, name) for name in self.args_names})
         return reproducing_arguments
 
@@ -337,3 +348,98 @@ class Transform(ABC):
     @staticmethod
     def get_sitk_interpolator(interpolation: str) -> int:
         return get_sitk_interpolator(interpolation)
+
+    @staticmethod
+    def parse_bounds(bounds_parameters: TypeBounds) -> TypeSixBounds:
+        try:
+            bounds_parameters = tuple(bounds_parameters)
+        except TypeError:
+            bounds_parameters = (bounds_parameters,)
+
+        # Check that numbers are integers
+        for number in bounds_parameters:
+            if not isinstance(number, (int, np.integer)) or number < 0:
+                message = (
+                    'Bounds values must be integers greater or equal to zero,'
+                    f' not "{bounds_parameters}" of type {type(number)}'
+                )
+                raise ValueError(message)
+        bounds_parameters = tuple(int(n) for n in bounds_parameters)
+        bounds_parameters_length = len(bounds_parameters)
+        if bounds_parameters_length == 6:
+            return bounds_parameters
+        if bounds_parameters_length == 1:
+            return 6 * bounds_parameters
+        if bounds_parameters_length == 3:
+            return tuple(np.repeat(bounds_parameters, 2).tolist())
+        message = (
+            'Bounds parameter must be an integer or a tuple of'
+            f' 3 or 6 integers, not {bounds_parameters}'
+        )
+        raise ValueError(message)
+
+    @staticmethod
+    def ones(tensor: torch.Tensor) -> torch.Tensor:
+        return torch.ones_like(tensor, dtype=torch.bool)
+
+    @staticmethod
+    def mean(tensor: torch.Tensor) -> torch.Tensor:
+        mask = tensor > tensor.mean()
+        return mask
+
+    @staticmethod
+    def get_mask(masking_method: TypeMaskingMethod, subject: Subject, tensor: torch.Tensor) -> torch.Tensor:
+        if masking_method is None:
+            return Transform.ones(tensor)
+        elif callable(masking_method):
+            return masking_method(tensor)
+        elif type(masking_method) is str:
+            if masking_method in subject and isinstance(subject[masking_method], LabelMap):
+                return subject[masking_method].data.bool()
+            if masking_method.title() in ('Left', 'Right', 'Anterior', 'Posterior', 'Inferior', 'Superior'):
+                return Transform.get_mask_from_anatomical_label(masking_method.title(), tensor)
+        elif type(masking_method) in (tuple, list, int):
+            return Transform.get_mask_from_bounds(masking_method, tensor)
+        message = (
+            'Masking method parameter must be a function, a label map name,'
+            " an anatomical label: ('Left', 'Right', 'Anterior', 'Posterior', 'Inferior', 'Superior'),"
+            ' or a bounds parameter: (an int, tuple of 3 ints, or tuple of 6 ints)'
+            f' not {masking_method} of type {type(masking_method)}'
+        )
+        raise ValueError(message)
+
+    @staticmethod
+    def get_mask_from_anatomical_label(anatomical_label: str, tensor: torch.Tensor) -> torch.Tensor:
+        anatomical_label = anatomical_label.title()
+        if anatomical_label.title() not in ('Left', 'Right', 'Anterior', 'Posterior', 'Inferior', 'Superior'):
+            message = (
+                "Anatomical label must be one of ('Left', 'Right', 'Anterior', 'Posterior', 'Inferior', 'Superior')"
+                f' not {anatomical_label}'
+            )
+            raise ValueError(message)
+        mask = torch.zeros_like(tensor, dtype=torch.bool)
+        _, width, height, depth = tensor.shape
+        if anatomical_label == 'Right':
+            mask[:, width // 2:] = True
+        elif anatomical_label == 'Left':
+            mask[:, :width // 2] = True
+        elif anatomical_label == 'Anterior':
+            mask[:, :, height // 2:] = True
+        elif anatomical_label == 'Posterior':
+            mask[:, :, :height // 2] = True
+        elif anatomical_label == 'Superior':
+            mask[:, :, :, depth // 2:] = True
+        elif anatomical_label == 'Inferior':
+            mask[:, :, :, :depth // 2] = True
+        return mask
+
+    @staticmethod
+    def get_mask_from_bounds(bounds_parameters: TypeBounds, tensor: torch.Tensor) -> torch.Tensor:
+        bounds_parameters = Transform.parse_bounds(bounds_parameters)
+        low = bounds_parameters[::2]
+        high = bounds_parameters[1::2]
+        i0, j0, k0 = low
+        i1, j1, k1 = np.array(tensor.shape[1:]) - high
+        mask = torch.zeros_like(tensor, dtype=torch.bool)
+        mask[:, i0:i1, j0:j1, k0:k1] = True
+        return mask

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -311,7 +311,9 @@ class Transform(ABC):
         Return a dictionary with the arguments that would be necessary to
         reproduce the transform exactly.
         """
-        return {name: getattr(self, name) for name in self.args_names}
+        reproducing_arguments = dict(include=self.include, exclude=self.exclude, copy=self.copy)
+        reproducing_arguments.update({name: getattr(self, name) for name in self.args_names})
+        return reproducing_arguments
 
     def is_invertible(self):
         return hasattr(self, 'invert_transform')

--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -209,3 +209,9 @@ def history_collate(batch: Sequence, collate_transforms=True):
         if hasattr(first_element, attr):
             dictionary.update({attr: [getattr(d, attr) for d in batch]})
         return dictionary
+
+
+def get_subclasses(target_class: type) -> List[type]:
+    subclasses = target_class.__subclasses__()
+    subclasses += sum([get_subclasses(cls) for cls in subclasses], [])
+    return subclasses

--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -213,5 +213,5 @@ def history_collate(batch: Sequence, collate_transforms=True):
 
 def get_subclasses(target_class: type) -> List[type]:
     subclasses = target_class.__subclasses__()
-    subclasses += sum([get_subclasses(cls) for cls in subclasses], [])
+    subclasses += sum((get_subclasses(cls) for cls in subclasses), [])
     return subclasses


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Implements #400.

**Description**
This implements new label transformations `RemapLabels`, `SequentialLabels`, `RemoveLabels`. Documentation and basic tests are included as well. Please let me know if anything should be improved or changed.

Some extra methods were added to `TorchioTestCase` for easier testing of these new transformations.
- `get_subject_with_labels(self, labels):` returns a subject with a `LabelMap` which has the desired set of `labels`.
- `get_unique_labels(self, label_map):` returns the set of unique labels in a `LabelMap`, not including 0.

A small fix to `Subject.apply_inverse_transform`.  Just applied `.clear_history()` to the subject after the inverse transformation.

Moved everything related to `TypeBounds`, and `TypeMaskingMethod` up to the `Transform` class so they can be reused in the label transformations. 

**Demonstration**

Original labels:
<img src="https://user-images.githubusercontent.com/5416313/103230909-c7b96180-48f3-11eb-9343-e705df708d13.png" width="500">

Apply `tio.RemoveLabels([1, 2, 17, 23, 24])`
<img src="https://user-images.githubusercontent.com/5416313/103230981-f1728880-48f3-11eb-8ae2-dd753fced758.png" width="500">

Apply `tio.RemapLabels({4:3, 6:5, 10:9, 20:19, 22:21}, masking_method="Right")`
<img src="https://user-images.githubusercontent.com/5416313/103231061-267edb00-48f4-11eb-935c-d73bc92d39af.png" width="500">

Apply `tio.SequentialLabels()`
<img src="https://user-images.githubusercontent.com/5416313/103231108-41514f80-48f4-11eb-9a7f-20473786e2d7.png" width="500">

Apply `subject = subject.apply_inverse_transform()`
<img src="https://user-images.githubusercontent.com/5416313/103231241-94c39d80-48f4-11eb-9e3b-d0ee3d6e3afe.png" width="500">

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
