### PR TITLE
Allow empty list as input to Compose.

### DIFF
--- a/torchio/transforms/augmentation/composition.py
+++ b/torchio/transforms/augmentation/composition.py
@@ -23,8 +23,6 @@ class Compose(Transform):
     """
     def __init__(self, transforms: Sequence[Transform], **kwargs):
         super().__init__(**kwargs)
-        if not transforms:
-            raise ValueError('The list of transforms is empty')
         for transform in transforms:
             if not callable(transform):
                 message = (
@@ -65,12 +63,9 @@ class Compose(Transform):
                 message = f'Skipping {transform.name} as it is not invertible'
                 warnings.warn(message, RuntimeWarning)
         transforms.reverse()
-        if transforms:
-            result = Compose(transforms)
-        else:  # return noop if no invertible transforms are found
-            def result(x): return x  # noqa: E704
-            if warn:
-                warnings.warn('No invertible transforms found', RuntimeWarning)
+        result = Compose(transforms)
+        if not transforms:
+            warnings.warn('No invertible transforms found', RuntimeWarning)
         return result
 
 

--- a/torchio/transforms/augmentation/composition.py
+++ b/torchio/transforms/augmentation/composition.py
@@ -64,7 +64,7 @@ class Compose(Transform):
                 warnings.warn(message, RuntimeWarning)
         transforms.reverse()
         result = Compose(transforms)
-        if not transforms:
+        if not transforms and warn:
             warnings.warn('No invertible transforms found', RuntimeWarning)
         return result
 

--- a/torchio/transforms/augmentation/composition.py
+++ b/torchio/transforms/augmentation/composition.py
@@ -39,7 +39,7 @@ class Compose(Transform):
         return self.transforms[index]
 
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}({self.transforms})'
+        return f'{self.name}({self.transforms})'
 
     def apply_transform(self, subject: Subject) -> Subject:
         for transform in self.transforms:

--- a/torchio/transforms/augmentation/composition.py
+++ b/torchio/transforms/augmentation/composition.py
@@ -30,7 +30,7 @@ class Compose(Transform):
                     f' are not callable: "{transform}"'
                 )
                 raise TypeError(message)
-        self.transforms = transforms
+        self.transforms = list(transforms)
 
     def __len__(self):
         return len(self.transforms)
@@ -39,7 +39,7 @@ class Compose(Transform):
         return self.transforms[index]
 
     def __repr__(self) -> str:
-        return repr(self.transforms)
+        return f'{self.__class__.__name__}({self.transforms})'
 
     def apply_transform(self, subject: Subject) -> Subject:
         for transform in self.transforms:


### PR DESCRIPTION
**Description**

This PR is just a small suggestion to allow empty lists as an input to a transform `Compose`. At the moment an error is raised in this case, but I think it would be nicer to return a null transform. This would be important if you are building a list of transforms dynamically and there is a chance of having an empty list. If the empty list case is not explicitly handled then this will introduce a hidden bug.

I ran into this situation when I was trying to construct a transform inverse, but only including the label transformations:

```python
label_transformations = []
for transform in subject.history:
    if type(transform) in (tio.RemapLabels, tio.RemoveLabels, tio.SequentialLabels):
        label_transformations.append(transform)
inverse_label_transform = tio.Compose(label_transformations ).inverse(warn=False)
```
This code worked until a case where the subject did not have any label transformations applied.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [x] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
