### PR TITLE
Add option to keep copies of original images

### DIFF
--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -209,6 +209,21 @@ class TestTransforms(TorchioTestCase):
         with self.assertWarns(DeprecationWarning):
             tio.RandomNoise(keys=['t2'])
 
+    def test_keep_original(self):
+        subject = copy.deepcopy(self.sample_subject)
+        old, new = 't1', 't1_original'
+        transformed = tio.RandomAffine(keep={old: new})(subject)
+        assert old in transformed
+        assert new in transformed
+        self.assertTensorEqual(
+            transformed[new].data,
+            subject[old].data,
+        )
+        self.assertTensorNotEqual(
+            transformed[new].data,
+            transformed[old].data,
+        )
+
 
 class TestTransform(TorchioTestCase):
 

--- a/torchio/transforms/data_parser.py
+++ b/torchio/transforms/data_parser.py
@@ -59,8 +59,10 @@ class DataParser:
         elif isinstance(self.data, dict):  # e.g. Eisen or MONAI dicts
             if self.keys is None:
                 message = (
-                    'If input is a dictionary, a value for "include" must be'
-                    ' specified when instantiating the transform'
+                    'If the input is a dictionary, a value for "include" must'
+                    ' be specified when instantiating the transform. See the'
+                    ' docs for Transform:'
+                    ' https://torchio.readthedocs.io/transforms/transforms.html#torchio.transforms.Transform'  # noqa: E501
                 )
                 raise RuntimeError(message)
             subject = self._get_subject_from_dict(self.data, self.keys)


### PR DESCRIPTION
Resolves #93.

**Description**
This adds a kwarg to keep images in subject untouched after applying the transform.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
