### PR TITLE
Small improvements for Queue

### DIFF
--- a/tests/data/test_queue.py
+++ b/tests/data/test_queue.py
@@ -17,7 +17,7 @@ class TestQueue(TorchioTestCase):
             force=False,
         )
 
-    def test_queue(self):
+    def run_queue(self, num_workers):
         subjects_dataset = SubjectsDataset(self.subjects_list)
         patch_size = 10
         sampler = UniformSampler(patch_size)
@@ -26,11 +26,14 @@ class TestQueue(TorchioTestCase):
             max_length=6,
             samples_per_volume=2,
             sampler=sampler,
-            num_workers=0,
-            verbose=True,
+            num_workers=num_workers,
         )
         _ = str(queue_dataset)
         batch_loader = DataLoader(queue_dataset, batch_size=4)
         for batch in batch_loader:
             _ = batch['one_modality'][DATA]
             _ = batch['segmentation'][DATA]
+
+    def test_queue(self):
+        self.run_queue(0)
+        self.run_queue(2)

--- a/tests/data/test_queue.py
+++ b/tests/data/test_queue.py
@@ -17,7 +17,7 @@ class TestQueue(TorchioTestCase):
             force=False,
         )
 
-    def run_queue(self, num_workers):
+    def run_queue(self, num_workers, **kwargs):
         subjects_dataset = SubjectsDataset(self.subjects_list)
         patch_size = 10
         sampler = UniformSampler(patch_size)
@@ -26,7 +26,7 @@ class TestQueue(TorchioTestCase):
             max_length=6,
             samples_per_volume=2,
             sampler=sampler,
-            num_workers=num_workers,
+            **kwargs,
         )
         _ = str(queue_dataset)
         batch_loader = DataLoader(queue_dataset, batch_size=4)
@@ -35,5 +35,10 @@ class TestQueue(TorchioTestCase):
             _ = batch['segmentation'][DATA]
 
     def test_queue(self):
-        self.run_queue(0)
-        self.run_queue(2)
+        self.run_queue(num_workers=0)
+
+    def test_queue_multiprocessing(self):
+        self.run_queue(num_workers=2)
+
+    def test_queue_no_start_background(self):
+        self.run_queue(num_workers=0, start_background=False)

--- a/torchio/data/queue.py
+++ b/torchio/data/queue.py
@@ -228,15 +228,20 @@ class Queue(Dataset):
             subject = next(self.subjects_iterable)
         return subject
 
+    @staticmethod
+    def get_first_item(batch):
+        return batch[0]
+
     def get_subjects_iterable(self) -> Iterator:
         # I need a DataLoader to handle parallelism
         # But this loader is always expected to yield single subject samples
         self._print(
-            '\nCreating subjects loader with', self.num_workers, 'workers')
+            f'\nCreating subjects loader with {self.num_workers} workers')
         subjects_loader = DataLoader(
             self.subjects_dataset,
             num_workers=self.num_workers,
-            collate_fn=lambda x: x[0],
+            batch_size=1,
+            collate_fn=self.get_first_item,
             shuffle=self.shuffle_subjects,
         )
         return iter(subjects_loader)

--- a/torchio/data/queue.py
+++ b/torchio/data/queue.py
@@ -66,6 +66,8 @@ class Queue(Dataset):
         num_workers: Number of subprocesses to use for data loading
             (as in :class:`torch.utils.data.DataLoader`).
             ``0`` means that the data will be loaded in the main process.
+        pin_memory: See :attr:`pin_memory` in
+            :class:`~torch.utils.data.DataLoader`.
         shuffle_subjects: If ``True``, the subjects dataset is shuffled at the
             beginning of each epoch, i.e. when all patches from all subjects
             have been processed.
@@ -135,6 +137,7 @@ class Queue(Dataset):
             samples_per_volume: int,
             sampler: PatchSampler,
             num_workers: int = 0,
+            pin_memory: bool = True,
             shuffle_subjects: bool = True,
             shuffle_patches: bool = True,
             start_background: bool = True,
@@ -147,6 +150,7 @@ class Queue(Dataset):
         self.samples_per_volume = samples_per_volume
         self.sampler = sampler
         self.num_workers = num_workers
+        self.pin_memory = pin_memory
         self.verbose = verbose
         self._subjects_iterable = None
         if start_background:
@@ -254,6 +258,7 @@ class Queue(Dataset):
         subjects_loader = DataLoader(
             self.subjects_dataset,
             num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
             batch_size=1,
             collate_fn=self.get_first_item,
             shuffle=self.shuffle_subjects,

--- a/torchio/data/queue.py
+++ b/torchio/data/queue.py
@@ -54,15 +54,15 @@ class Queue(Dataset):
     which are passed to the neural network.
 
     Args:
-        subjects_dataset: Instance of
-            :class:`~torchio.data.SubjectsDataset`.
+        subjects_dataset: Instance of :class:`~torchio.data.SubjectsDataset`.
         max_length: Maximum number of patches that can be stored in the queue.
             Using a large number means that the queue needs to be filled less
             often, but more CPU memory is needed to store the patches.
         samples_per_volume: Number of patches to extract from each volume.
             A small number of patches ensures a large variability in the queue,
             but training will be slower.
-        sampler: A sampler used to extract patches from the volumes.
+        sampler: A subclass of :class:`~torchio.data.sampler.PatchSampler` used
+            to extract patches from the volumes.
         num_workers: Number of subprocesses to use for data loading
             (as in :class:`torch.utils.data.DataLoader`).
             ``0`` means that the data will be loaded in the main process.
@@ -71,7 +71,7 @@ class Queue(Dataset):
             have been processed.
         shuffle_patches: If ``True``, patches are shuffled after filling the
             queue.
-        verbose: If ``True``, some debugging messages are printed.
+        verbose: If ``True``, some debugging messages will be printed.
 
     This diagram represents the connection between
     a :class:`~torchio.data.SubjectsDataset`,
@@ -94,7 +94,9 @@ class Queue(Dataset):
 
     .. note:: :attr:`num_workers` refers to the number of workers used to
         load and transform the volumes. Multiprocessing is not needed to pop
-        patches from the queue.
+        patches from the queue, so you should always use ``num_workers=0`` for
+        the :class:`~torch.utils.data.DataLoader` you instantiate to generate
+        training batches.
 
     Example:
 


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #422.
Related to #366.

**Description**
This PR adds some improvements to the queue:
1. Add option to defer loading, as the default is to start loading at instantiation time
2. Add `pin_memory` flag for the data loader
3. Stop using a `lambda` as `collate_fn` as this is problematic for multiprocessing

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [ ] Non-breaking change (would not break existing functionality)
- [x] Breaking change (would cause existing functionality to change) (as the default behavior is now to pin_memory, but the difference is expected to be small)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
