### PR TITLE
Add some label transforms for binary morphological operations

### DIFF
--- a/docs/source/transforms/preprocessing.rst
+++ b/docs/source/transforms/preprocessing.rst
@@ -122,6 +122,13 @@ Label
     :show-inheritance:
 
 
+:class:`Contour`
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: Contour
+    :show-inheritance:
+
+
 :class:`KeepLargestComponent`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/transforms/preprocessing.rst
+++ b/docs/source/transforms/preprocessing.rst
@@ -120,3 +120,10 @@ Label
 
 .. autoclass:: OneHot
     :show-inheritance:
+
+
+:class:`KeepLargestComponent`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: KeepLargestComponent
+    :show-inheritance:

--- a/torchio/cli/apply_transform.py
+++ b/torchio/cli/apply_transform.py
@@ -15,6 +15,12 @@ import click
     help='String of kwargs, e.g. "degrees=(-5,15) num_transforms=3".',
 )
 @click.option(
+    '--imclass', '-c',
+    type=str,
+    default='ScalarImage',
+    help='Subclass of torchio.Image used to instantiate the image.'
+)
+@click.option(
     '--seed', '-s',
     type=int,
     help='Seed for PyTorch random number generator.',
@@ -30,6 +36,7 @@ def main(
         transform_name,
         output_path,
         kwargs,
+        imclass,
         seed,
         verbose,
         ):
@@ -59,6 +66,7 @@ def main(
         transform,
         output_path,
         verbose=verbose,
+        class_=imclass,
     )
     return 0
 

--- a/torchio/transforms/__init__.py
+++ b/torchio/transforms/__init__.py
@@ -37,6 +37,7 @@ from .preprocessing import EnsureShapeMultiple
 from .preprocessing import HistogramStandardization
 from .preprocessing.intensity.histogram_standardization import train_histogram
 from .preprocessing import OneHot
+from .preprocessing import Contour
 from .preprocessing import RemapLabels
 from .preprocessing import RemoveLabels
 from .preprocessing import SequentialLabels
@@ -87,6 +88,7 @@ __all__ = [
     'EnsureShapeMultiple',
     'train_histogram',
     'OneHot',
+    'Contour',
     'RemapLabels',
     'RemoveLabels',
     'SequentialLabels',

--- a/torchio/transforms/__init__.py
+++ b/torchio/transforms/__init__.py
@@ -40,6 +40,7 @@ from .preprocessing import OneHot
 from .preprocessing import RemapLabels
 from .preprocessing import RemoveLabels
 from .preprocessing import SequentialLabels
+from .preprocessing import KeepLargestComponent
 
 
 __all__ = [
@@ -89,4 +90,5 @@ __all__ = [
     'RemapLabels',
     'RemoveLabels',
     'SequentialLabels',
+    'KeepLargestComponent',
 ]

--- a/torchio/transforms/preprocessing/__init__.py
+++ b/torchio/transforms/preprocessing/__init__.py
@@ -10,6 +10,7 @@ from .intensity.z_normalization import ZNormalization
 from .intensity.histogram_standardization import HistogramStandardization
 
 from .label.one_hot import OneHot
+from .label.contour import Contour
 from .label.remap_labels import RemapLabels
 from .label.remove_labels import RemoveLabels
 from .label.sequential_labels import SequentialLabels
@@ -27,6 +28,7 @@ __all__ = [
     'RescaleIntensity',
     'HistogramStandardization',
     'OneHot',
+    'Contour',
     'RemapLabels',
     'RemoveLabels',
     'SequentialLabels',

--- a/torchio/transforms/preprocessing/__init__.py
+++ b/torchio/transforms/preprocessing/__init__.py
@@ -13,6 +13,7 @@ from .label.one_hot import OneHot
 from .label.remap_labels import RemapLabels
 from .label.remove_labels import RemoveLabels
 from .label.sequential_labels import SequentialLabels
+from .label.keep_largest_component import KeepLargestComponent
 
 
 __all__ = [
@@ -29,4 +30,5 @@ __all__ = [
     'RemapLabels',
     'RemoveLabels',
     'SequentialLabels',
+    'KeepLargestComponent',
 ]

--- a/torchio/transforms/preprocessing/label/contour.py
+++ b/torchio/transforms/preprocessing/label/contour.py
@@ -1,0 +1,24 @@
+import SimpleITK as sitk
+
+from .label_transform import LabelTransform
+
+
+class Contour(LabelTransform):
+    r"""Keep only the borders of each connected component in a binary image.
+
+    Args:
+        **kwargs: See :class:`~torchio.transforms.Transform` for additional
+            keyword arguments.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.args_names = []
+
+    def apply_transform(self, subject):
+        for image in self.get_images(subject):
+            assert image.data.ndim == 4 and image.data.shape[0] == 1
+            sitk_image = image.as_sitk()
+            contour = sitk.BinaryContour(sitk_image)
+            tensor, _ = self.sitk_to_nib(contour)
+            image.set_data(tensor)
+        return subject

--- a/torchio/transforms/preprocessing/label/keep_largest_component.py
+++ b/torchio/transforms/preprocessing/label/keep_largest_component.py
@@ -1,0 +1,35 @@
+import SimpleITK as sitk
+
+from .label_transform import LabelTransform
+
+
+class KeepLargestComponent(LabelTransform):
+    r"""Keep only the largest connected component in a binary label map.
+
+    Args:
+        **kwargs: See :class:`~torchio.transforms.Transform` for additional
+            keyword arguments.
+
+    .. note:: For now, this transform only works for binary images, i.e., label
+        maps with a background and a foreground class. If you are interested in
+        extending this transform `open a new issue`_.
+
+    .. _open a new issue: https://github.com/fepegar/torchio/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=Improve%20KeepLargestComponent%20transform
+    """  # noqa: E501
+    def __init__(
+            self,
+            **kwargs
+            ):
+        super().__init__(**kwargs)
+        self.args_names = []
+
+    def apply_transform(self, subject):
+        for image in self.get_images(subject):
+            assert image.data.ndim == 4 and image.data.shape[0] == 1
+            sitk_image = image.as_sitk()
+            connected_components = sitk.ConnectedComponent(sitk_image)
+            labeled_cc = sitk.RelabelComponent(connected_components)
+            largest_cc = labeled_cc == 1
+            tensor, _ = self.sitk_to_nib(largest_cc)
+            image.set_data(tensor)
+        return subject

--- a/torchio/transforms/preprocessing/label/keep_largest_component.py
+++ b/torchio/transforms/preprocessing/label/keep_largest_component.py
@@ -16,10 +16,7 @@ class KeepLargestComponent(LabelTransform):
 
     .. _open a new issue: https://github.com/fepegar/torchio/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=Improve%20KeepLargestComponent%20transform
     """  # noqa: E501
-    def __init__(
-            self,
-            **kwargs
-            ):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.args_names = []
 

--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -11,7 +11,6 @@ import nibabel as nib
 import SimpleITK as sitk
 from tqdm import trange
 
-from .constants import INTENSITY
 from .typing import TypeNumber, TypePath
 
 
@@ -114,11 +113,12 @@ def apply_transform_to_file(
         input_path: TypePath,
         transform,  # : Transform seems to create a circular import
         output_path: TypePath,
-        type: str = INTENSITY,  # noqa: A002
+        class_: str = 'ScalarImage',
         verbose: bool = False,
         ):
-    from . import Image, Subject
-    subject = Subject(image=Image(input_path, type=type))
+    from . import data
+    image = getattr(data, class_)(input_path)
+    subject = data.Subject(image=image)
     transformed = transform(subject)
     transformed.image.save(output_path)
     if verbose and transformed.history:


### PR DESCRIPTION
**Description**
1. A tiny, convenient transform to remove all connected components in a binary label map but the largest.
2. One more transform to keep only the borders of the connected components.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
