### PR TITLE
Add EPISURG dataset

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -20,6 +20,19 @@ IXI
     :show-inheritance:
 
 
+EPISURG
+-------
+
+.. currentmodule:: torchio.datasets.episurg
+
+:class:`EPISURG`
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: EPISURG
+    :members:
+    :show-inheritance:
+
+
 MNI
 ---
 

--- a/torchio/datasets/__init__.py
+++ b/torchio/datasets/__init__.py
@@ -1,5 +1,6 @@
 from .fpg import FPG
 from .slicer import Slicer
+from .episurg import EPISURG
 from .ixi import IXI, IXITiny
 from .itk_snap import BrainTumor, T1T2, AorticValve
 from .mni import Colin27, Sheep, Pediatric, ICBM2009CNonlinearSymmetric
@@ -10,6 +11,7 @@ __all__ = [
     'Slicer',
     'IXI',
     'IXITiny',
+    'EPISURG',
     'BrainTumor',
     'T1T2',
     'AorticValve',

--- a/torchio/datasets/episurg.py
+++ b/torchio/datasets/episurg.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+from typing import Optional
+
+from ..typing import TypePath
+from ..transforms import Transform
+from ..download import download_and_extract_archive
+from .. import SubjectsDataset, Subject, ScalarImage, LabelMap
+
+
+class EPISURG(SubjectsDataset):
+    """
+    `EPISURG`_ is a clinical dataset of :math:`T_1`-weighted MRI from 430
+    epileptic patients who underwent resective brain surgery at the National
+    Hospital of Neurology and Neurosurgery (Queen Square, London, United
+    Kingdom) between 1990 and 2018.
+
+    The dataset comprises 430 postoperative MRI. The corresponding preoperative
+    MRI is present for 268 subjects.
+
+    Three human raters segmented the resection cavity on partially overlapping
+    subsets of EPISURG.
+
+    If you use this dataset for your research, you agree with the *Data use
+    agreement* presented at the EPISURG entry on the `UCL Research Data
+    Repository <EPISURG>`_ and you must cite the corresponding publications.
+
+    .. _EPISURG: https://doi.org/10.5522/04/9996158.v1
+
+    Args:
+        root: Root directory to which the dataset will be downloaded.
+        transform: An instance of
+            :class:`~torchio.transforms.transform.Transform`.
+        download: If set to ``True``, will download the data into :attr:`root`.
+
+    .. warning:: The size of this dataset is multiple GB.
+        If you set :attr:`download` to ``True``, it will take some time
+        to be downloaded if it is not already present.
+    """
+
+    data_url = 'https://s3-eu-west-1.amazonaws.com/pstorage-ucl-2748466690/26153588/EPISURG.zip'  # noqa: E501
+    md5 = '5ec5831a2c6fbfdc8489ba2910a6504b'
+
+    def __init__(
+            self,
+            root: TypePath,
+            transform: Optional[Transform] = None,
+            download: bool = False,
+            **kwargs,
+            ):
+        root = Path(root).expanduser().absolute()
+        if download:
+            self._download(root)
+        subjects_list = self._get_subjects_list(root)
+        self.kwargs = kwargs
+        super().__init__(subjects_list, transform=transform, **kwargs)
+
+    @staticmethod
+    def _check_exists(root, modalities):
+        for modality in modalities:
+            modality_dir = root / modality
+            if not modality_dir.is_dir():
+                exists = False
+                break
+        else:
+            exists = True
+        return exists
+
+    @staticmethod
+    def _get_subjects_list(root):
+        subjects_dir = root / 'EPISURG' / 'subjects'
+        subjects = []
+        for subject_dir in sorted(subjects_dir.glob('sub-*')):
+            subject_id = subject_dir.name[-4:]
+            images_dict = {'subject_id': subject_id}
+            preop_dir = subject_dir / 'preop'
+            preop_paths = list(preop_dir.glob('*preop*'))
+            assert len(preop_paths) <= 1
+            if preop_paths:
+                images_dict['preop_mri'] = ScalarImage(preop_paths[0])
+            postop_dir = subject_dir / 'postop'
+            postop_path = list(postop_dir.glob('*postop-t1mri*'))[0]
+            images_dict['postop_mri'] = ScalarImage(postop_path)
+            for seg_path in postop_dir.glob('*seg*'):
+                seg_id = seg_path.name[-8]
+                images_dict[f'seg_{seg_id}'] = LabelMap(seg_path)
+            subjects.append(Subject(**images_dict))
+        return subjects
+
+    def _download(self, root):
+        """Download the EPISURG data if it does not exist already."""
+        if (root / 'EPISURG').is_dir():
+            return
+        root.mkdir(exist_ok=True, parents=True)
+        download_and_extract_archive(
+            self.data_url,
+            download_root=root,
+            md5=self.md5,
+        )
+        (root / 'EPISURG.zip').unlink()  # cleanup
+
+    def _glob_subjects(self, string):
+        subjects = []
+        for subject in self._subjects:
+            for image_name in subject:
+                if string in image_name:
+                    subjects.append(subject)
+                    break
+        return subjects
+
+    def _get_labeled_subjects(self):
+        return self._glob_subjects('seg')
+
+    def _get_paired_subjects(self):
+        return self._glob_subjects('preop')
+
+    def _get_subset(self, subjects):
+        dataset = SubjectsDataset(
+            subjects,
+            transform=self._transform,
+            **(self.kwargs),
+        )
+        return dataset
+
+    def get_labeled(self) -> SubjectsDataset:
+        """Get dataset from subjects with manual annotations."""
+        return self._get_subset(self._get_labeled_subjects())
+
+    def get_unlabeled(self) -> SubjectsDataset:
+        """Get dataset from subjects without manual annotations."""
+        subjects = [
+            s for s in self._subjects
+            if s not in self._get_labeled_subjects()
+        ]
+        return self._get_subset(subjects)
+
+    def get_paired(self) -> SubjectsDataset:
+        """Get dataset from subjects with pre- and post-op MRI."""
+        return self._get_subset(self._get_paired_subjects())


### PR DESCRIPTION
[Link to EPISURG entry on the UCL Research Data Repository](https://rdr.ucl.ac.uk/articles/dataset/EPISURG_a_dataset_of_postoperative_magnetic_resonance_images_MRI_for_quantitative_analysis_of_resection_neurosurgery_for_refractory_epilepsy/9996158).