### PR TITLE
added list of masks functionality to HistogramStandardization.train

### DIFF
--- a/tests/transforms/preprocessing/test_histogram_standardization.py
+++ b/tests/transforms/preprocessing/test_histogram_standardization.py
@@ -10,33 +10,45 @@ class TestHistogramStandardization(TorchioTestCase):
 
     def setUp(self):
         super().setUp()
-        self.subjects = [
-            Subject(
-                image=ScalarImage(self.get_image_path(f'hs_image_{i}')),
-                label=LabelMap(
-                    self.get_image_path(
-                        f'hs_label_{i}',
-                        binary=True,
-                        force_binary_foreground=True,
-                    ),
-                ),
-            )
-            for i in range(5)
-        ]
+        subjects = []
+        for i in range(5):
+            image = ScalarImage(self.get_image_path(f'hs_image_{i}'))
+            label_path = self.get_image_path(
+                f'hs_label_{i}', binary=True, force_binary_foreground=True)
+            label = LabelMap(label_path)
+            subject = Subject(image=image, label=label)
+            subjects.append(subject)
+        self.subjects = subjects
         self.dataset = SubjectsDataset(self.subjects)
 
     def test_train_histogram(self):
-        paths = [sample['image']['path'] for sample in self.dataset]
+        paths = [subject.image.path for subject in self.dataset]
+        # Use a function to mask
         HistogramStandardization.train(
             paths,
             masking_function=HistogramStandardization.mean,
             output_path=(self.dir / 'landmarks.txt'),
         )
+        # Use a file to mask
         HistogramStandardization.train(
             paths,
-            mask_path=self.dataset[0]['label']['path'],
+            mask_path=self.dataset[0].label.path,
             output_path=(self.dir / 'landmarks.npy'),
         )
+        # Use files to mask
+        masks = [subject.label.path for subject in self.dataset]
+        HistogramStandardization.train(
+            paths,
+            mask_path=masks,
+            output_path=(self.dir / 'landmarks_masks.npy'),
+        )
+
+    def test_bad_paths_lengths(self):
+        with self.assertRaises(ValueError):
+            HistogramStandardization.train(
+                [1, 2],
+                mask_path=[1, 2, 3],
+            )
 
     def test_normalize(self):
         landmarks = np.linspace(0, 100, 13)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #444.

**Description**
As discussed, just added a functionality for multiple masks.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x ] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [ x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [ x] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [ x] This pull request is ready to be reviewed
- [ x] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
