### PR TITLE
Add support for custom image readers

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -179,3 +179,21 @@ class TestImage(TorchioTestCase):
         with self.assertWarns(DeprecationWarning):
             im = self.sample_subject.t1
             im.data = im.data
+
+    def test_custom_reader(self):
+        path = self.dir / 'im.npy'
+
+        def numpy_reader(path):
+            return np.load(path), np.eye(4)
+
+        def assert_shape(shape_in, shape_out):
+            np.save(path, np.random.rand(*shape_in))
+            image = tio.ScalarImage(path, reader=numpy_reader)
+            assert image.shape == shape_out
+
+        assert_shape((5, 5), (1, 5, 5, 1))
+        assert_shape((5, 5, 3), (3, 5, 5, 1))
+        assert_shape((3, 5, 5), (3, 5, 5, 1))
+        assert_shape((5, 5, 5), (1, 5, 5, 5))
+        assert_shape((1, 5, 5, 5), (1, 5, 5, 5))
+        assert_shape((4, 5, 5, 5), (4, 5, 5, 5))

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -24,7 +24,7 @@ class TestIO(TorchioTestCase):
             '0.0906326 0.18661 0.978245 11.4002 '
             '0 0 0 1 '
         )
-        tensor = torch.from_numpy(np.fromstring(string, sep=' ').reshape(4, 4))
+        tensor = torch.as_tensor(np.fromstring(string, sep=' ').reshape(4, 4))
         self.matrix = tensor
 
     def test_read_image(self):

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -388,7 +388,7 @@ class Image(dict):
                 raise RuntimeError('Input tensor cannot be None')
         if isinstance(tensor, np.ndarray):
             tensor = check_uint_to_int(tensor)
-            tensor = torch.from_numpy(tensor)
+            tensor = torch.as_tensor(tensor)
         elif not isinstance(tensor, torch.Tensor):
             message = 'Input tensor must be a PyTorch tensor or NumPy array'
             raise TypeError(message)

--- a/torchio/data/io.py
+++ b/torchio/data/io.py
@@ -21,7 +21,13 @@ def read_image(path: TypePath) -> Tuple[torch.Tensor, np.ndarray]:
         try:
             result = _read_nibabel(path)
         except nib.loadsave.ImageFileError:
-            raise RuntimeError(f'File "{path}" not understood')
+            message = (
+                f'File "{path}" not understood.'
+                ' Check supported formats by at'
+                ' https://simpleitk.readthedocs.io/en/master/IO.html#images'
+                ' and https://nipy.org/nibabel/api.html#file-formats'
+            )
+            raise RuntimeError(message)
     return result
 
 

--- a/torchio/data/io.py
+++ b/torchio/data/io.py
@@ -32,7 +32,7 @@ def _read_nibabel(path: TypePath) -> Tuple[torch.Tensor, np.ndarray]:
         data = data[..., 0, :]
         data = data.transpose(3, 0, 1, 2)
     data = check_uint_to_int(data)
-    tensor = torch.from_numpy(data)
+    tensor = torch.as_tensor(data)
     affine = img.affine
     return tensor, affine
 
@@ -44,7 +44,7 @@ def _read_sitk(path: TypePath) -> Tuple[torch.Tensor, np.ndarray]:
         image = sitk.ReadImage(str(path))
     data, affine = sitk_to_nib(image, keepdim=True)
     data = check_uint_to_int(data)
-    tensor = torch.from_numpy(data)
+    tensor = torch.as_tensor(data)
     return tensor, affine
 
 
@@ -180,7 +180,7 @@ def _read_itk_matrix(path):
     matrix = np.hstack([rotation_matrix, translation_vector])
     homogeneous_matrix_lps = np.vstack([matrix, [0, 0, 0, 1]])
     homogeneous_matrix_ras = _from_itk_convention(homogeneous_matrix_lps)
-    return torch.from_numpy(homogeneous_matrix_ras)
+    return torch.as_tensor(homogeneous_matrix_ras)
 
 
 def _write_itk_matrix(matrix, tfm_path):
@@ -201,7 +201,7 @@ def _read_niftyreg_matrix(trsf_path):
     """Read a NiftyReg matrix and return it as a NumPy array"""
     matrix = np.loadtxt(trsf_path)
     matrix = np.linalg.inv(matrix)
-    return torch.from_numpy(matrix)
+    return torch.as_tensor(matrix)
 
 
 def _write_niftyreg_matrix(matrix, txt_path):

--- a/torchio/data/io.py
+++ b/torchio/data/io.py
@@ -304,6 +304,7 @@ def sitk_to_nib(
 
 def ensure_4d(tensor: TypeData, num_spatial_dims=None) -> TypeData:
     # I wish named tensors were properly supported in PyTorch
+    tensor = torch.as_tensor(tensor)
     num_dimensions = tensor.ndim
     if num_dimensions == 4:
         pass

--- a/torchio/transforms/augmentation/intensity/random_bias_field.py
+++ b/torchio/transforms/augmentation/intensity/random_bias_field.py
@@ -111,7 +111,7 @@ class BiasField(IntensityTransform):
                 image.data, order, coefficients)
             if self.invert_transform:
                 np.divide(1, bias_field, out=bias_field)
-            image.set_data(image.data * torch.from_numpy(bias_field))
+            image.set_data(image.data * torch.as_tensor(bias_field))
         return subject
 
     @staticmethod

--- a/torchio/transforms/augmentation/intensity/random_blur.py
+++ b/torchio/transforms/augmentation/intensity/random_blur.py
@@ -97,5 +97,5 @@ def blur(
     assert data.ndim == 3
     std_physical = np.array(std_voxel) / np.array(spacing)
     blurred = ndi.gaussian_filter(data, std_physical)
-    tensor = torch.from_numpy(blurred)
+    tensor = torch.as_tensor(blurred)
     return tensor

--- a/torchio/transforms/augmentation/intensity/random_ghosting.py
+++ b/torchio/transforms/augmentation/intensity/random_ghosting.py
@@ -212,7 +212,7 @@ class Ghosting(IntensityTransform, FourierTransform):
 
         array_ghosts = self.inv_fourier_transform(spectrum)
         array_ghosts = np.real(array_ghosts).astype(np.float32)
-        return torch.from_numpy(array_ghosts)
+        return torch.as_tensor(array_ghosts)
 
 
 def _parse_restore(restore):

--- a/torchio/transforms/augmentation/intensity/random_motion.py
+++ b/torchio/transforms/augmentation/intensity/random_motion.py
@@ -180,7 +180,7 @@ class Motion(IntensityTransform, FourierTransform):
                 )
                 result_arrays.append(transformed_channel)
             result = np.stack(result_arrays)
-            image.set_data(torch.from_numpy(result))
+            image.set_data(torch.as_tensor(result))
         return subject
 
     def get_rigid_transforms(

--- a/torchio/transforms/augmentation/intensity/random_spike.py
+++ b/torchio/transforms/augmentation/intensity/random_spike.py
@@ -148,4 +148,4 @@ class Spike(IntensityTransform, FourierTransform):
             # #i, j, k = mid_shape - diff
             # #spectrum[i, j, k] = spectrum.max() * intensity_factor
         result = np.real(self.inv_fourier_transform(spectrum))
-        return torch.from_numpy(result.astype(np.float32))
+        return torch.as_tensor(result.astype(np.float32))

--- a/torchio/transforms/augmentation/spatial/random_affine.py
+++ b/torchio/transforms/augmentation/spatial/random_affine.py
@@ -345,7 +345,7 @@ class Affine(SpatialTransform):
 
         np_array = sitk.GetArrayFromImage(resampled)
         np_array = np_array.transpose()  # ITK to NumPy
-        tensor = torch.from_numpy(np_array)
+        tensor = torch.as_tensor(np_array)
         return tensor
 
 

--- a/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
+++ b/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
@@ -296,7 +296,7 @@ class ElasticDeformation(SpatialTransform):
             resampler.SetOutputPixelType(sitk.sitkFloat32)
             resampled = resampler.Execute(floating)
             result, _ = self.sitk_to_nib(resampled)
-            results.append(torch.from_numpy(result))
+            results.append(torch.as_tensor(result))
         tensor = torch.cat(results)
         return tensor
 

--- a/torchio/transforms/augmentation/spatial/random_flip.py
+++ b/torchio/transforms/augmentation/spatial/random_flip.py
@@ -126,5 +126,5 @@ def _flip_image(image, axes):
     data = image.numpy()
     data = np.flip(data, axis=spatial_axes)
     data = data.copy()  # remove negative strides
-    data = torch.from_numpy(data)
+    data = torch.as_tensor(data)
     image.set_data(data)

--- a/torchio/transforms/preprocessing/intensity/histogram_standardization.py
+++ b/torchio/transforms/preprocessing/intensity/histogram_standardization.py
@@ -287,7 +287,7 @@ def normalize(
     new_img = lin_img * data + aff_img
     new_img = new_img.reshape(shape)
     new_img = new_img.astype(np.float32)
-    new_img = torch.from_numpy(new_img)
+    new_img = torch.as_tensor(new_img)
     return new_img
 
 

--- a/torchio/transforms/preprocessing/intensity/rescale.py
+++ b/torchio/transforms/preprocessing/intensity/rescale.py
@@ -78,4 +78,4 @@ class RescaleIntensity(NormalizationTransform):
         out_range = self.out_max - self.out_min
         array *= out_range  # [0, out_range]
         array += self.out_min  # [out_min, out_max]
-        return torch.from_numpy(array)
+        return torch.as_tensor(array)

--- a/torchio/transforms/preprocessing/spatial/pad.py
+++ b/torchio/transforms/preprocessing/spatial/pad.py
@@ -85,7 +85,7 @@ class Pad(BoundsTransform):
             pad_params = self.bounds_parameters
             paddings = (0, 0), pad_params[:2], pad_params[2:4], pad_params[4:]
             padded = np.pad(image.data, paddings, **kwargs)
-            image.set_data(torch.from_numpy(padded))
+            image.set_data(torch.as_tensor(padded))
             image.affine = new_affine
         return subject
 

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -206,7 +206,7 @@ class Resample(SpatialTransform):
             resampled = resampler.Execute(floating_itk)
 
             array, affine = sitk_to_nib(resampled)
-            image.set_data(torch.from_numpy(array))
+            image.set_data(torch.as_tensor(array))
             image.affine = affine
         return subject
 

--- a/torchio/transforms/preprocessing/spatial/to_canonical.py
+++ b/torchio/transforms/preprocessing/spatial/to_canonical.py
@@ -41,6 +41,6 @@ class ToCanonical(SpatialTransform):
             # https://github.com/facebookresearch/InferSent/issues/99#issuecomment-446175325
             array = array.copy()
             array = array.transpose(3, 4, 0, 1, 2)  # (1, C, W, H, D)
-            image.set_data(torch.from_numpy(array[0]))
+            image.set_data(torch.as_tensor(array[0]))
             image.affine = reoriented.affine
         return subject


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Related to #453, #439, #328.

**Description**
Add a kwarg to `Image` so custom readers can be used for lazy loading.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
