### PR TITLE
Fix probabilities in label sampler

### DIFF
--- a/tests/data/sampler/test_label_sampler.py
+++ b/tests/data/sampler/test_label_sampler.py
@@ -19,9 +19,10 @@ class TestLabelSampler(TorchioTestCase):
         )
         subject = tio.SubjectsDataset([subject])[0]
         probs_dict = {0: 0, 1: 50, 2: 25, 3: 25}
-        sampler = tio.LabelSampler(5, 'label', label_probabilities=probs_dict)
+        patch_size = (1, 1, 5)
+        sampler = tio.LabelSampler(patch_size, label_probabilities=probs_dict)
         probabilities = sampler.get_probability_map(subject)
-        fixture = torch.Tensor((0, 0, 2 / 12, 2 / 12, 3 / 12, 2 / 12, 0))
+        fixture = torch.Tensor((0, 0, 1 / 4, 1 / 4, 1 / 4, 0, 0))
         assert torch.all(probabilities.squeeze().eq(fixture))
 
     def test_inconsistent_shape(self):


### PR DESCRIPTION
Fixes #458.

**Description**
The problem is illustrated in the gist in #458.

The implemented solution is to use a cropped version of the label map
to compute the probability map, padding it at the end.

The values for cropping and padding are computed from the patch size.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
