### PR TITLE
Add input range kwarg for RescaleIntensity

### DIFF
--- a/tests/transforms/augmentation/test_random_anisotropy.py
+++ b/tests/transforms/augmentation/test_random_anisotropy.py
@@ -9,7 +9,7 @@ class TestRandomAnisotropy(TorchioTestCase):
     def test_downsample(self):
         transform = RandomAnisotropy(
             axes=1,
-            downsampling=(2., 2.)
+            downsampling=(2, 2)
         )
         transformed = transform(self.sample_subject)
         self.assertEqual(

--- a/tests/transforms/augmentation/test_random_bias_field.py
+++ b/tests/transforms/augmentation/test_random_bias_field.py
@@ -6,7 +6,7 @@ from ...utils import TorchioTestCase
 class TestRandomBiasField(TorchioTestCase):
 
     def test_no_bias(self):
-        transform = tio.RandomBiasField(coefficients=0.)
+        transform = tio.RandomBiasField(coefficients=0)
         transformed = transform(self.sample_subject)
         self.assertTensorAlmostEqual(
             self.sample_subject.t1.data,

--- a/tests/transforms/augmentation/test_random_ghosting.py
+++ b/tests/transforms/augmentation/test_random_ghosting.py
@@ -66,7 +66,7 @@ class TestRandomGhosting(TorchioTestCase):
 
     def test_out_of_range_restore(self):
         with self.assertRaises(ValueError):
-            RandomGhosting(restore=-1.)
+            RandomGhosting(restore=-1)
 
     def test_wrong_restore_type(self):
         with self.assertRaises(TypeError):

--- a/tests/transforms/augmentation/test_random_labels_to_image.py
+++ b/tests/transforms/augmentation/test_random_labels_to_image.py
@@ -142,8 +142,8 @@ class TestRandomLabelsToImage(TorchioTestCase):
         transform = RandomLabelsToImage(
             label_key='label',
             image_key='t1',
-            default_std=0.,
-            default_mean=-1.
+            default_std=0,
+            default_mean=-1,
         )
         original_t1 = self.sample_subject.t1.data.clone()
         transformed = transform(self.sample_subject)

--- a/tests/transforms/augmentation/test_random_noise.py
+++ b/tests/transforms/augmentation/test_random_noise.py
@@ -5,7 +5,7 @@ from ...utils import TorchioTestCase
 class TestRandomNoise(TorchioTestCase):
     """Tests for `RandomNoise`."""
     def test_no_noise(self):
-        transform = RandomNoise(mean=0., std=0.)
+        transform = RandomNoise(mean=0, std=0)
         transformed = transform(self.sample_subject)
         self.assertTensorAlmostEqual(
             self.sample_subject.t1.data,
@@ -21,7 +21,7 @@ class TestRandomNoise(TorchioTestCase):
         )
 
     def test_constant_noise(self):
-        transform = RandomNoise(mean=(5., 5.), std=0.)
+        transform = RandomNoise(mean=(5, 5), std=0)
         transformed = transform(self.sample_subject)
         self.assertTensorAlmostEqual(
             self.sample_subject.t1.data + 5,

--- a/tests/transforms/preprocessing/test_rescale.py
+++ b/tests/transforms/preprocessing/test_rescale.py
@@ -1,15 +1,16 @@
+import torch
+import torchio as tio
 import numpy as np
-from torchio.transforms import RescaleIntensity
 from ...utils import TorchioTestCase
 
 
 class TestRescaleIntensity(TorchioTestCase):
-    """Tests for :class:`RescaleIntensity` class."""
+    """Tests for :class:`tio.RescaleIntensity` class."""
 
     def test_rescale_to_same_intentisy(self):
         min_t1 = float(self.sample_subject.t1.data.min())
         max_t1 = float(self.sample_subject.t1.data.max())
-        transform = RescaleIntensity(out_min_max=(min_t1, max_t1))
+        transform = tio.RescaleIntensity(out_min_max=(min_t1, max_t1))
         transformed = transform(self.sample_subject)
         assert np.allclose(
             transformed.t1.data,
@@ -19,10 +20,10 @@ class TestRescaleIntensity(TorchioTestCase):
         )
 
     def test_min_max(self):
-        transform = RescaleIntensity(out_min_max=(0., 1.))
+        transform = tio.RescaleIntensity(out_min_max=(0, 1))
         transformed = transform(self.sample_subject)
-        self.assertEqual(transformed.t1.data.min(), 0.)
-        self.assertEqual(transformed.t1.data.max(), 1.)
+        self.assertEqual(transformed.t1.data.min(), 0)
+        self.assertEqual(transformed.t1.data.max(), 1)
 
     def test_percentiles(self):
         low_quantile = np.percentile(self.sample_subject.t1.data, 5)
@@ -31,14 +32,14 @@ class TestRescaleIntensity(TorchioTestCase):
             as_tuple=True)
         high_indices = (self.sample_subject.t1.data > high_quantile).nonzero(
             as_tuple=True)
-        transform = RescaleIntensity(out_min_max=(0., 1.), percentiles=(5, 95))
-        transformed = transform(self.sample_subject)
-        assert (transformed.t1.data[low_indices] == 0.).all()
-        assert (transformed.t1.data[high_indices] == 1.).all()
+        rescale = tio.RescaleIntensity(out_min_max=(0, 1), percentiles=(5, 95))
+        transformed = rescale(self.sample_subject)
+        assert (transformed.t1.data[low_indices] == 0).all()
+        assert (transformed.t1.data[high_indices] == 1).all()
 
     def test_masking_using_label(self):
-        transform = RescaleIntensity(
-            out_min_max=(0., 1.), percentiles=(5, 95), masking_method='label')
+        transform = tio.RescaleIntensity(
+            out_min_max=(0, 1), percentiles=(5, 95), masking_method='label')
         transformed = transform(self.sample_subject)
         mask = self.sample_subject.label.data > 0
         low_quantile = np.percentile(self.sample_subject.t1.data[mask], 5)
@@ -47,31 +48,47 @@ class TestRescaleIntensity(TorchioTestCase):
             as_tuple=True)
         high_indices = (self.sample_subject.t1.data > high_quantile).nonzero(
             as_tuple=True)
-        self.assertEqual(transformed.t1.data.min(), 0.)
-        self.assertEqual(transformed.t1.data.max(), 1.)
-        assert (transformed.t1.data[low_indices] == 0.).all()
-        assert (transformed.t1.data[high_indices] == 1.).all()
+        self.assertEqual(transformed.t1.data.min(), 0)
+        self.assertEqual(transformed.t1.data.max(), 1)
+        assert (transformed.t1.data[low_indices] == 0).all()
+        assert (transformed.t1.data[high_indices] == 1).all()
+
+    def test_ct(self):
+        ct_max = 1500
+        ct_min = -2000
+        ct_range = ct_max - ct_min
+        tensor = torch.rand(1, 30, 30, 30) * ct_range + ct_min
+        ct = tio.ScalarImage(tensor=tensor)
+        ct_air = -1000
+        ct_bone = 1000
+        rescale = tio.RescaleIntensity(
+            out_min_max=(-1, 1),
+            in_min_max=(ct_air, ct_bone),
+        )
+        rescaled = rescale(ct)
+        assert rescaled.data.min() < -1
+        assert rescaled.data.max() > 1
 
     def test_out_min_higher_than_out_max(self):
         with self.assertRaises(ValueError):
-            RescaleIntensity(out_min_max=(1., 0.))
+            tio.RescaleIntensity(out_min_max=(1, 0))
 
     def test_too_many_values_for_out_min_max(self):
         with self.assertRaises(ValueError):
-            RescaleIntensity(out_min_max=(1., 2., 3.))
+            tio.RescaleIntensity(out_min_max=(1, 2, 3))
 
     def test_wrong_out_min_max_type(self):
         with self.assertRaises(ValueError):
-            RescaleIntensity(out_min_max='wrong')
+            tio.RescaleIntensity(out_min_max='wrong')
 
     def test_min_percentile_higher_than_max_percentile(self):
         with self.assertRaises(ValueError):
-            RescaleIntensity(out_min_max=(0., 1.), percentiles=(1., 0.))
+            tio.RescaleIntensity(out_min_max=(0, 1), percentiles=(1, 0))
 
     def test_too_many_values_for_percentiles(self):
         with self.assertRaises(ValueError):
-            RescaleIntensity(out_min_max=(0., 1.), percentiles=(1., 2., 3.))
+            tio.RescaleIntensity(out_min_max=(0, 1), percentiles=(1, 2, 3))
 
     def test_wrong_percentiles_type(self):
         with self.assertRaises(ValueError):
-            RescaleIntensity(out_min_max=(0., 1.), percentiles='wrong')
+            tio.RescaleIntensity(out_min_max=(0, 1), percentiles='wrong')

--- a/tests/transforms/preprocessing/test_z_normalization.py
+++ b/tests/transforms/preprocessing/test_z_normalization.py
@@ -9,8 +9,8 @@ class TestZNormalization(TorchioTestCase):
     def test_z_normalization(self):
         transform = tio.ZNormalization()
         transformed = transform(self.sample_subject)
-        self.assertAlmostEqual(float(transformed.t1.data.mean()), 0., places=6)
-        self.assertAlmostEqual(float(transformed.t1.data.std()), 1.)
+        self.assertAlmostEqual(float(transformed.t1.data.mean()), 0, places=6)
+        self.assertAlmostEqual(float(transformed.t1.data.std()), 1)
 
     def test_no_std(self):
         image = tio.ScalarImage(tensor=torch.ones(1, 2, 2, 2))

--- a/torchio/datasets/slicer.py
+++ b/torchio/datasets/slicer.py
@@ -24,6 +24,14 @@ URLS_DICT = {
             'SHA256/67564aa42c7e2eec5c3fd68afb5a910e9eab837b61da780933716a3b922e50fe',  # noqa: E501
         ),
     ),
+    'CTChest': (
+        ('CT-chest.nrrd',),
+        ('SHA256/4507b664690840abb6cb9af2d919377ffc4ef75b167cb6fd0f747befdb12e38e',),  # noqa: E501
+    ),
+    'CTACardio': (
+        ('CTA-cardio.nrrd',),
+        ('SHA256/3b0d4eb1a7d8ebb0c5a89cc0504640f76a030b4e869e33ff34c564c3d3b88ad2',),  # noqa: E501
+    ),
 }
 
 

--- a/torchio/transforms/augmentation/intensity/random_ghosting.py
+++ b/torchio/transforms/augmentation/intensity/random_ghosting.py
@@ -216,8 +216,10 @@ class Ghosting(IntensityTransform, FourierTransform):
 
 
 def _parse_restore(restore):
-    if not isinstance(restore, float):
-        raise TypeError(f'Restore must be a float, not {restore}')
+    try:
+        restore = float(restore)
+    except Exception as e:
+        raise TypeError(f'Restore must be a float, not "{restore}"') from e
     if not 0 <= restore <= 1:
         message = (
             f'Restore must be a number between 0 and 1, not {restore}')

--- a/torchio/transforms/preprocessing/intensity/histogram_standardization.py
+++ b/torchio/transforms/preprocessing/intensity/histogram_standardization.py
@@ -202,8 +202,8 @@ def _standardize_cutoff(cutoff: np.ndarray) -> np.ndarray:
 
     """
     cutoff = np.asarray(cutoff)
-    cutoff[0] = max(0., cutoff[0])
-    cutoff[1] = min(1., cutoff[1])
+    cutoff[0] = max(0, cutoff[0])
+    cutoff[1] = min(1, cutoff[1])
     cutoff[0] = np.min([cutoff[0], 0.09])
     cutoff[1] = np.max([cutoff[1], 0.91])
     return cutoff

--- a/torchio/transforms/preprocessing/intensity/rescale.py
+++ b/torchio/transforms/preprocessing/intensity/rescale.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Optional, Tuple
 
 import torch
 import numpy as np
@@ -23,8 +24,18 @@ class RescaleIntensity(NormalizationTransform):
             :math:`(n_{min}, n_{max}) = (0, d)`.
         masking_method: See
             :class:`~torchio.transforms.preprocessing.intensity.NormalizationTransform`.
+        in_min_max: Range :math:`(m_{min}, m_{max})` of input intensities that
+            will be mapped to :math:`(n_{min}, n_{max})`. If ``None``, the
+            minimum and maximum input intensities will be used.
         **kwargs: See :class:`~torchio.transforms.Transform` for additional
             keyword arguments.
+
+    Example:
+        >>> import torchio as tio
+        >>> ct = tio.ScalarImage('ct_scan.nii.gz')
+        >>> ct_air, ct_bone = -1000, 1000
+        >>> rescale = tio.RescaleIntensity(out_min_max=(-1, 1), in_min_max=(ct_air, ct_bone))
+        >>> ct_normalized = rescale(ct)
 
     .. _this scikit-image example: https://scikit-image.org/docs/dev/auto_examples/color_exposure/plot_equalize.html#sphx-glr-auto-examples-color-exposure-plot-equalize-py
     .. _nn-UNet paper: https://arxiv.org/abs/1809.10486
@@ -34,10 +45,12 @@ class RescaleIntensity(NormalizationTransform):
             out_min_max: TypeRangeFloat = (0, 1),
             percentiles: TypeRangeFloat = (0, 100),
             masking_method: TypeMaskingMethod = None,
+            in_min_max: Optional[Tuple[float, float]] = None,
             **kwargs
             ):
         super().__init__(masking_method=masking_method, **kwargs)
         self.out_min_max = out_min_max
+        self.in_min_max = in_min_max
         self.out_min, self.out_max = self._parse_range(
             out_min_max, 'out_min_max')
         self.percentiles = self._parse_range(
@@ -65,17 +78,21 @@ class RescaleIntensity(NormalizationTransform):
         values = array[mask]
         cutoff = np.percentile(values, self.percentiles)
         np.clip(array, *cutoff, out=array)
-        array -= array.min()  # [0, max]
-        array_max = array.max()  # waiting for walrus operator
-        if array_max == 0:  # should this be compared using a tolerance?
+        if self.in_min_max is None:
+            in_min, in_max = array.min(), array.max()
+        else:
+            in_min, in_max = self.in_min_max
+        array -= in_min
+        in_range = in_max - in_min
+        if in_range == 0:  # should this be compared using a tolerance?
             message = (
                 f'Rescaling image "{image_name}" not possible'
                 ' due to division by zero'
             )
             warnings.warn(message, RuntimeWarning)
             return tensor
-        array /= array_max  # [0, 1]
+        array /= in_range
         out_range = self.out_max - self.out_min
-        array *= out_range  # [0, out_range]
-        array += self.out_min  # [out_min, out_max]
+        array *= out_range
+        array += self.out_min
         return torch.as_tensor(array)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #41.

**Description**
It is sometimes useful to specify an input range that will be linearly mapped to the output range. For example, users might want to map specific Hounsfield Units to -1 and 1, making the normalization transform robust to intensity outliers.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x]  Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
