### PR TITLE
Fix 0 prob random sample in WeightedSampler

### DIFF
--- a/torchio/constants.py
+++ b/torchio/constants.py
@@ -1,3 +1,5 @@
+import torch
+
 # Image types
 INTENSITY = 'intensity'
 LABEL = 'label'
@@ -22,3 +24,6 @@ REPO_URL = 'https://github.com/fepegar/torchio/'
 
 # Data repository
 DATA_REPO = 'https://github.com/fepegar/torchio-data/raw/master/data/'
+
+# Floating point error
+MIN_FLOAT_32 = torch.finfo(torch.float32).eps

--- a/torchio/data/sampler/weighted.py
+++ b/torchio/data/sampler/weighted.py
@@ -225,7 +225,10 @@ class WeightedSampler(RandomSampler):
 
         """  # noqa: E501
         # Get first value larger than random number
-        random_number = torch.rand(1).item()
+        # Ensure random number cannot be exactly 0.0.
+        random_number = max(
+            torch.rand(1).item(), torch.finfo(torch.float32).eps
+        )
         # If probability map is float32, cdf.max() can be far from 1, e.g. 0.92
         if random_number > cdf.max():
             cdf_index = -1


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #510.

**Description**
Ensures random number generated in `WeightedSampler.sample_probability_map()` cannot be exactly 0.0. This led to a rare event where the selected patch was centered at `(0, 0, 0)`, which may not have a probability > 0.

Performs a `max()` with the smallest increment possible for the dtype returned by `torch.rand()` (`torch.float32`).

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
