### PR TITLE
Avoid deprecation warnings

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -180,6 +180,10 @@ class TestImage(TorchioTestCase):
             im = self.sample_subject.t1
             im.data = im.data
 
+    def test_no_type(self):
+        with self.assertWarns(UserWarning):
+            tio.Image(tensor=torch.rand(1, 2, 3, 4))
+
     def test_custom_reader(self):
         path = self.dir / 'im.npy'
 

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -206,7 +206,7 @@ class TestTransforms(TorchioTestCase):
             tio.RandomNoise(include=['t2'], exclude=['t1'])
 
     def test_keys_deprecated(self):
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(UserWarning):
             tio.RandomNoise(keys=['t2'])
 
     def test_keep_original(self):

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -117,7 +117,7 @@ class Image(dict):
             warnings.warn(
                 'Not specifying the image type is deprecated and will be'
                 ' mandatory in the future. You can probably use tio.ScalarImage'
-                ' or tio.LabelMap instead', DeprecationWarning,
+                ' or tio.LabelMap instead',
             )
             type = INTENSITY
 

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -81,7 +81,7 @@ class Transform(ABC):
                 'The "keys" argument is deprecated and will be removed in the'
                 ' future. Use "include" instead.'
             )
-            warnings.warn(message, DeprecationWarning)
+            warnings.warn(message)
             include = keys
         self.include, self.exclude = self.parse_include_and_exclude(
             include, exclude)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Related to #515.

**Description**
As deprecation warnings are suppressed by default since Python 3.2, warnings are not shown when users instantiate a `torchio.Image`. This PR removes the explicit warning type, so `UserWarning`s are printed.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
