### PR TITLE
Make the grid sampler compatible with the queue

### DIFF
--- a/docs/examples/plot_history.py
+++ b/docs/examples/plot_history.py
@@ -1,6 +1,6 @@
 """
-Tracing applied transforms
-==========================
+Trace applied transforms
+========================
 
 Sometimes we would like to see which transform was applied to a certain batch
 during training. This can be done in TorchIO using

--- a/docs/source/data/patch_inference.rst
+++ b/docs/source/data/patch_inference.rst
@@ -1,9 +1,8 @@
 Inference
 =========
 
-
-Here's an example that uses a grid sampler and aggregator to perform dense
-inference across a 3D image using small patches::
+Here is an example that uses a grid sampler and aggregator to perform dense
+inference across a 3D image using patches::
 
     >>> import torch
     >>> import torch.nn as nn

--- a/docs/source/data/patch_training.rst
+++ b/docs/source/data/patch_training.rst
@@ -30,6 +30,12 @@ For more information about patch-based training, see
 .. autoclass:: PatchSampler
     :show-inheritance:
 
+
+.. autoclass:: GridSampler
+    :noindex:
+    :show-inheritance:
+
+
 Queue
 -----
 

--- a/tests/data/inference/test_grid_sampler.py
+++ b/tests/data/inference/test_grid_sampler.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from copy import copy
-from torchio.data import GridSampler
+import torchio as tio
 from ...utils import TorchioTestCase
 
 
@@ -11,7 +11,11 @@ class TestGridSampler(TorchioTestCase):
     def test_locations(self):
         patch_size = 5, 20, 20
         patch_overlap = 2, 4, 6
-        sampler = GridSampler(self.sample_subject, patch_size, patch_overlap)
+        sampler = tio.GridSampler(
+            subject=self.sample_subject,
+            patch_size=patch_size,
+            patch_overlap=patch_overlap,
+        )
         fixture = [
             [0, 0, 0, 5, 20, 20],
             [0, 0, 10, 5, 20, 30],
@@ -25,18 +29,18 @@ class TestGridSampler(TorchioTestCase):
 
     def test_large_patch(self):
         with self.assertRaises(ValueError):
-            GridSampler(self.sample_subject, (5, 21, 5), (0, 2, 0))
+            tio.GridSampler(self.sample_subject, (5, 21, 5), (0, 2, 0))
 
     def test_large_overlap(self):
         with self.assertRaises(ValueError):
-            GridSampler(self.sample_subject, (5, 20, 5), (2, 4, 6))
+            tio.GridSampler(self.sample_subject, (5, 20, 5), (2, 4, 6))
 
     def test_odd_overlap(self):
         with self.assertRaises(ValueError):
-            GridSampler(self.sample_subject, (5, 20, 5), (2, 4, 3))
+            tio.GridSampler(self.sample_subject, (5, 20, 5), (2, 4, 3))
 
     def test_single_location(self):
-        sampler = GridSampler(self.sample_subject, (10, 20, 30), 0)
+        sampler = tio.GridSampler(self.sample_subject, (10, 20, 30), 0)
         fixture = [[0, 0, 0, 10, 20, 30]]
         self.assertEqual(sampler.locations.tolist(), fixture)
 
@@ -44,7 +48,7 @@ class TestGridSampler(TorchioTestCase):
         patch_size = 5, 20, 20
         patch_overlap = 2, 4, 6
         initial_shape = copy(self.sample_subject.shape)
-        GridSampler(
+        tio.GridSampler(
             self.sample_subject,
             patch_size,
             patch_overlap,
@@ -52,3 +56,8 @@ class TestGridSampler(TorchioTestCase):
         )
         final_shape = self.sample_subject.shape
         self.assertEqual(initial_shape, final_shape)
+
+    def test_bad_subject(self):
+        with self.assertRaises(ValueError):
+            patch_size = 88
+            tio.GridSampler(patch_size)

--- a/torchio/data/__init__.py
+++ b/torchio/data/__init__.py
@@ -2,8 +2,9 @@ from .queue import Queue
 from .subject import Subject
 from .dataset import SubjectsDataset
 from .image import Image, ScalarImage, LabelMap
-from .inference import GridSampler, GridAggregator
+from .inference import GridAggregator
 from .sampler import (
+    GridSampler,
     PatchSampler,
     LabelSampler,
     WeightedSampler,

--- a/torchio/data/inference/__init__.py
+++ b/torchio/data/inference/__init__.py
@@ -1,4 +1,4 @@
-from .grid_sampler import GridSampler
+from ..sampler import GridSampler  # for backward compatibility
 from .aggregator import GridAggregator
 
 __all__ = [

--- a/torchio/data/inference/aggregator.py
+++ b/torchio/data/inference/aggregator.py
@@ -1,10 +1,12 @@
 import warnings
 from typing import Tuple
+
 import torch
 import numpy as np
+
 from ...typing import TypeData
 from ...constants import CHANNELS_DIMENSION
-from .grid_sampler import GridSampler
+from ..sampler import GridSampler
 
 
 class GridAggregator:

--- a/torchio/data/sampler/__init__.py
+++ b/torchio/data/sampler/__init__.py
@@ -1,9 +1,11 @@
+from .grid import GridSampler
 from .label import LabelSampler
 from .uniform import UniformSampler
 from .weighted import WeightedSampler
 from .sampler import PatchSampler, RandomSampler
 
 __all__ = [
+    'GridSampler',
     'LabelSampler',
     'UniformSampler',
     'WeightedSampler',

--- a/torchio/data/sampler/grid.py
+++ b/torchio/data/sampler/grid.py
@@ -1,16 +1,16 @@
-from typing import Union
+from typing import Union, Generator, Optional
 
 import numpy as np
-from torch.utils.data import Dataset
 
 from ...utils import to_tuple
 from ...constants import LOCATION
-from ...typing import TypeTuple, TypeTripletInt
-from ..subject import Subject
-from ..sampler.sampler import PatchSampler
+from ...data.subject import Subject
+from ...typing import TypePatchSize
+from ...typing import TypeTripletInt
+from .sampler import PatchSampler
 
 
-class GridSampler(PatchSampler, Dataset):
+class GridSampler(PatchSampler):
     r"""Extract patches across a whole volume.
 
     Grid samplers are useful to perform inference using all patches from a
@@ -18,7 +18,10 @@ class GridSampler(PatchSampler, Dataset):
 
     Args:
         subject: Instance of :class:`~torchio.data.Subject`
-            from which patches will be extracted.
+            from which patches will be extracted. This argument should only be
+            used before instantiating a :class:`~torchio.data.GridAggregator`,
+            or to precompute the number of patches that would be generated from
+            a subject.
         patch_size: Tuple of integers :math:`(w, h, d)` to generate patches
             of size :math:`w \times h \times d`.
             If a single number :math:`n` is provided,
@@ -36,6 +39,19 @@ class GridSampler(PatchSampler, Dataset):
             :class:`~torchio.data.GridAggregator`, it will crop the output
             to its original size.
 
+    Example::
+
+        >>> import torchio as tio
+        >>> sampler = tio.GridSampler(patch_size=88)
+        >>> colin = tio.datasets.Colin27()
+        >>> for i, patch in enumerate(sampler(colin)):
+        ...     patch.t1.save(f'patch_{i}.nii.gz')
+        ...
+        >>> # To figure out the number of patches beforehand:
+        >>> sampler = tio.GridSampler(subject=colin, patch_size=88)
+        >>> len(sampler)
+        8
+
     .. note:: Adapted from NiftyNet. See `this NiftyNet tutorial
         <https://niftynet.readthedocs.io/en/dev/window_sizes.html>`_ for more
         information about patch based sampling. Note that
@@ -44,24 +60,18 @@ class GridSampler(PatchSampler, Dataset):
     """
     def __init__(
             self,
-            subject: Subject,
-            patch_size: TypeTuple,
-            patch_overlap: TypeTuple = (0, 0, 0),
+            subject: Optional[Subject] = None,
+            patch_size: TypePatchSize = None,
+            patch_overlap: TypePatchSize = (0, 0, 0),
             padding_mode: Union[str, float, None] = None,
             ):
-        self.subject = subject
+        if patch_size is None:
+            raise ValueError('A value for patch_size must be given')
+        super().__init__(patch_size)
         self.patch_overlap = np.array(to_tuple(patch_overlap, length=3))
         self.padding_mode = padding_mode
-        if padding_mode is not None:
-            from ...transforms import Pad
-            border = self.patch_overlap // 2
-            padding = border.repeat(2)
-            pad = Pad(padding, padding_mode=padding_mode)
-            self.subject = pad(self.subject)
-        PatchSampler.__init__(self, patch_size)
-        sizes = self.subject.spatial_shape, self.patch_size, self.patch_overlap
-        self.parse_sizes(*sizes)
-        self.locations = self.get_patches_locations(*sizes)
+        self.subject = self._pad(subject)
+        self.locations = self._compute_locations(self.subject)
 
     def __len__(self):
         return len(self.locations)
@@ -74,8 +84,36 @@ class GridSampler(PatchSampler, Dataset):
         cropped_subject[LOCATION] = location
         return cropped_subject
 
+    def _pad(self, subject: Subject) -> Subject:
+        if self.padding_mode is not None:
+            from ...transforms import Pad
+            border = self.patch_overlap // 2
+            padding = border.repeat(2)
+            pad = Pad(padding, padding_mode=self.padding_mode)
+            subject = pad(subject)
+        return subject
+
+    def _compute_locations(self, subject: Subject):
+        if subject is None:
+            return None
+        sizes = subject.spatial_shape, self.patch_size, self.patch_overlap
+        self._parse_sizes(*sizes)
+        return self._get_patches_locations(*sizes)
+
+    def _generate_patches(
+            self,
+            subject: Subject,
+            ) -> Generator[Subject, None, None]:
+        subject = self._pad(subject)
+        sizes = subject.spatial_shape, self.patch_size, self.patch_overlap
+        self._parse_sizes(*sizes)
+        locations = self._get_patches_locations(*sizes)
+        for location in locations:
+            index_ini = location[:3]
+            yield self.extract_patch(subject, index_ini)
+
     @staticmethod
-    def parse_sizes(
+    def _parse_sizes(
             image_size: TypeTripletInt,
             patch_size: TypeTripletInt,
             patch_overlap: TypeTripletInt,
@@ -103,7 +141,7 @@ class GridSampler(PatchSampler, Dataset):
             raise ValueError(message)
 
     @staticmethod
-    def get_patches_locations(
+    def _get_patches_locations(
             image_size: TypeTripletInt,
             patch_size: TypeTripletInt,
             patch_overlap: TypeTripletInt,

--- a/torchio/data/sampler/grid.py
+++ b/torchio/data/sampler/grid.py
@@ -26,6 +26,8 @@ class GridSampler(PatchSampler):
             of size :math:`w \times h \times d`.
             If a single number :math:`n` is provided,
             :math:`w = h = d = n`.
+            This argument is mandatory (it is a keyword argument for backward
+            compatibility).
         patch_overlap: Tuple of even integers :math:`(w_o, h_o, d_o)`
             specifying the overlap between patches for dense inference. If a
             single number :math:`n` is provided, :math:`w_o = h_o = d_o = n`.
@@ -70,6 +72,8 @@ class GridSampler(PatchSampler):
         super().__init__(patch_size)
         self.patch_overlap = np.array(to_tuple(patch_overlap, length=3))
         self.padding_mode = padding_mode
+        if subject is not None and not isinstance(subject, Subject):
+            raise ValueError('The subject argument must be None or Subject')
         self.subject = self._pad(subject)
         self.locations = self._compute_locations(self.subject)
 

--- a/torchio/data/sampler/uniform.py
+++ b/torchio/data/sampler/uniform.py
@@ -1,6 +1,5 @@
 import torch
 from ...data.subject import Subject
-from ...typing import TypePatchSize
 from .sampler import RandomSampler
 from typing import Generator
 import numpy as np
@@ -16,20 +15,11 @@ class UniformSampler(RandomSampler):
     def get_probability_map(self, subject: Subject) -> torch.Tensor:
         return torch.ones(1, *subject.spatial_shape)
 
-    def __call__(
+    def _generate_patches(
             self,
             subject: Subject,
             num_patches: int = None,
             ) -> Generator[Subject, None, None]:
-        subject.check_consistent_spatial_shape()
-
-        if np.any(self.patch_size > subject.spatial_shape):
-            message = (
-                f'Patch size {tuple(self.patch_size)} cannot be'
-                f' larger than image size {tuple(subject.spatial_shape)}'
-            )
-            raise RuntimeError(message)
-
         valid_range = subject.spatial_shape - self.patch_size
         patches_left = num_patches if num_patches is not None else True
         while patches_left:

--- a/torchio/data/sampler/weighted.py
+++ b/torchio/data/sampler/weighted.py
@@ -57,18 +57,11 @@ class WeightedSampler(RandomSampler):
         self.probability_map_name = probability_map
         self.cdf = None
 
-    def __call__(
+    def _generate_patches(
             self,
             subject: Subject,
             num_patches: Optional[int] = None,
             ) -> Generator[Subject, None, None]:
-        subject.check_consistent_space()
-        if np.any(self.patch_size > subject.spatial_shape):
-            message = (
-                f'Patch size {tuple(self.patch_size)} cannot be'
-                f' larger than image size {tuple(subject.spatial_shape)}'
-            )
-            raise RuntimeError(message)
         probability_map = self.get_probability_map(subject)
         probability_map = self.process_probability_map(
             probability_map, subject)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->

Resolves #513.
Related to #505, #494.

**Description**
This PR makes the grid sampler behave like the other samplers, so that it can be used with the queue as requested by some users (@sarthakpati, @MFaizyabAli).

The new API is not very clean, but it allows for backward compatibility with the tutorials for dense inference using the aggregator.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
