### PR TITLE
Set minimum version for NumPy requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ furo
 humanize
 matplotlib
 nibabel
-numpy
+numpy>=1.15
 scipy
 sphinx-copybutton
 sphinx-gallery

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     'Deprecated',
     'humanize',
     'nibabel',
-    'numpy',
+    'numpy>=1.15',
     'scipy',
     'torch>=1.1',
     'tqdm',

--- a/torchio/transforms/augmentation/spatial/random_flip.py
+++ b/torchio/transforms/augmentation/spatial/random_flip.py
@@ -125,7 +125,7 @@ def _ensure_axes_indices(subject, axes):
 def _flip_image(image, axes):
     spatial_axes = np.array(axes, int) + 1
     data = image.numpy()
-    data = np.flip(data, axis=spatial_axes.tolist())
+    data = np.flip(data, axis=spatial_axes)
     data = data.copy()  # remove negative strides
     data = torch.as_tensor(data)
     image.set_data(data)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #529.

**Description**
Setting the NumPy requirement to `numpy>=1.15.0` so an iterable for `axes` can be passed to [`np.flip`](https://numpy.org/doc/stable/reference/generated/numpy.flip.html).

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
