### PR TITLE
Added Image method to convert from sitk to torchio

### DIFF
--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -18,6 +18,7 @@ from .io import (
     read_image,
     write_image,
     nib_to_sitk,
+    sitk_to_nib,
     check_uint_to_int,
     get_rotation_and_spacing_from_affine,
 )
@@ -502,6 +503,11 @@ class Image(dict):
     def as_sitk(self, **kwargs) -> sitk.Image:
         """Get the image as an instance of :class:`sitk.Image`."""
         return nib_to_sitk(self.data, self.affine, **kwargs)
+
+    @classmethod
+    def from_sitk(cls, sitk_image):
+        tensor, affine = sitk_to_nib(sitk_image)
+        return cls(tensor=tensor, affine=affine)
 
     def as_pil(self, transpose=True):
         """Get the image as an instance of :class:`PIL.Image`.


### PR DESCRIPTION
Fixes #615.

**Description**
This PR relates to discussions in #612 about being able to convert from an in-memory SimpleITK image into a torchio image object. This small PR adds a class method to `torchio.Image` for doing this simple conversion.

I am much more expert in `R` package development - in fact, this is the first `python` package I have ever contributed code to. So if I have done anything wrong or more work needs to be done, please let me know and I will try to improve this PR. FWIW, I was able to install this update locally and tested the new method interactively and it worked as expected.

```py
import torchio as tio
img_sitk = tio.datasets.Colin27().t1.as_sitk()
img = tio.ScalarImage.from_sitk(img_sitk)
print(img)
```
```
ScalarImage(shape: (1, 181, 217, 181); spacing: (1.00, 1.00, 1.00); orientation: RAS+; memory: 27.1 MiB; dtype: torch.FloatTensor)
```

**Checklist**

- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
