### PR TITLE
Fixed example section of from_sitk docstring

### DIFF
--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -509,14 +509,14 @@ class Image(dict):
         """Instantiate a new TorchIO image from a :class:`sitk.Image`.
 
         Example:
-        >>> import torchio as tio
-        >>> import SimpleITK as sitk
-        >>> sitk_image = sitk.Image(20, 30, 40, sitk.sitkUInt16)
-        >>> tio.LabelMap.from_sitk(sitk_image)
-        LabelMap(shape: (1, 20, 30, 40); spacing: (1.00, 1.00, 1.00); orientation: LPS+; memory: 93.8 KiB; dtype: torch.IntTensor)
-        >>> sitk_image = sitk.Image((224, 224), sitk.sitkVectorFloat32, 3)
-        >>> tio.ScalarImage.from_sitk(sitk_image)
-        ScalarImage(shape: (3, 224, 224, 1); spacing: (1.00, 1.00, 1.00); orientation: LPS+; memory: 588.0 KiB; dtype: torch.FloatTensor)
+            >>> import torchio as tio
+            >>> import SimpleITK as sitk
+            >>> sitk_image = sitk.Image(20, 30, 40, sitk.sitkUInt16)
+            >>> tio.LabelMap.from_sitk(sitk_image)
+            LabelMap(shape: (1, 20, 30, 40); spacing: (1.00, 1.00, 1.00); orientation: LPS+; memory: 93.8 KiB; dtype: torch.IntTensor)
+            >>> sitk_image = sitk.Image((224, 224), sitk.sitkVectorFloat32, 3)
+            >>> tio.ScalarImage.from_sitk(sitk_image)
+            ScalarImage(shape: (3, 224, 224, 1); spacing: (1.00, 1.00, 1.00); orientation: LPS+; memory: 588.0 KiB; dtype: torch.FloatTensor)
         """
         tensor, affine = sitk_to_nib(sitk_image)
         return cls(tensor=tensor, affine=affine)


### PR DESCRIPTION
Fixes issue arising from 5a008fd1e85c633bc4615833bf1f9573708d4d33.

See https://torchio.readthedocs.io/data/image.html#torchio.Image.from_sitk

**Description**
A few sentences describing the changes proposed in this pull request.

**Checklist**
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
