### PR TITLE
Added intensity clamp transform

### DIFF
--- a/docs/source/transforms/preprocessing.rst
+++ b/docs/source/transforms/preprocessing.rst
@@ -33,9 +33,16 @@ Intensity
 
 
 :class:`Mask`
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. autoclass:: Mask
+    :show-inheritance:
+
+
+:class:`Clamp`
+~~~~~~~~~~~~~~
+
+.. autoclass:: Clamp
     :show-inheritance:
 
 

--- a/tests/transforms/preprocessing/test_clamp.py
+++ b/tests/transforms/preprocessing/test_clamp.py
@@ -3,11 +3,11 @@ import torchio as tio
 from ...utils import TorchioTestCase
 
 
-class TestClampIntensity(TorchioTestCase):
-    """Tests for :class:`tio.ClampIntensity` class."""
+class TestClamp(TorchioTestCase):
+    """Tests for :class:`tio.Clamp` class."""
 
     def test_out_min_max(self):
-        transform = tio.ClampIntensity(out_min=0, out_max=1)
+        transform = tio.Clamp(out_min=0, out_max=1)
         transformed = transform(self.sample_subject)
         self.assertEqual(transformed.t1.data.min(), 0)
         self.assertEqual(transformed.t1.data.max(), 1)
@@ -20,27 +20,27 @@ class TestClampIntensity(TorchioTestCase):
         ct = tio.ScalarImage(tensor=tensor)
         ct_air = -1000
         ct_bone = 1000
-        clamp = tio.ClampIntensity(ct_air, ct_bone)
+        clamp = tio.Clamp(ct_air, ct_bone)
         clamped = clamp(ct)
         assert clamped.data.min() == ct_air
         assert clamped.data.max() == ct_bone
 
     def test_too_many_values_for_out_min(self):
         with self.assertRaises(TypeError):
-            clamp = tio.ClampIntensity(out_min=(1, 2))
+            clamp = tio.Clamp(out_min=(1, 2))
             clamp(self.sample_subject)
 
     def test_too_many_values_for_out_max(self):
         with self.assertRaises(TypeError):
-            clamp = tio.ClampIntensity(out_max=(1, 2))
+            clamp = tio.Clamp(out_max=(1, 2))
             clamp(self.sample_subject)
 
     def test_wrong_out_min_type(self):
         with self.assertRaises(TypeError):
-            clamp = tio.ClampIntensity(out_min='foo')
+            clamp = tio.Clamp(out_min='foo')
             clamp(self.sample_subject)
 
     def test_wrong_out_max_type(self):
         with self.assertRaises(TypeError):
-            clamp = tio.ClampIntensity(out_max='foo')
+            clamp = tio.Clamp(out_max='foo')
             clamp(self.sample_subject)

--- a/tests/transforms/preprocessing/test_clamp.py
+++ b/tests/transforms/preprocessing/test_clamp.py
@@ -1,0 +1,46 @@
+import torch
+import torchio as tio
+from ...utils import TorchioTestCase
+
+
+class TestClampIntensity(TorchioTestCase):
+    """Tests for :class:`tio.ClampIntensity` class."""
+
+    def test_out_min_max(self):
+        transform = tio.ClampIntensity(out_min=0, out_max=1)
+        transformed = transform(self.sample_subject)
+        self.assertEqual(transformed.t1.data.min(), 0)
+        self.assertEqual(transformed.t1.data.max(), 1)
+
+    def test_ct(self):
+        ct_max = 1500
+        ct_min = -2000
+        ct_range = ct_max - ct_min
+        tensor = torch.rand(1, 30, 30, 30) * ct_range + ct_min
+        ct = tio.ScalarImage(tensor=tensor)
+        ct_air = -1000
+        ct_bone = 1000
+        clamp = tio.ClampIntensity(ct_air, ct_bone)
+        clamped = clamp(ct)
+        assert clamped.data.min() == ct_air
+        assert clamped.data.max() == ct_bone
+
+    def test_too_many_values_for_out_min(self):
+        with self.assertRaises(TypeError):
+            clamp = tio.ClampIntensity(out_min=(1, 2))
+            clamp(self.sample_subject)
+
+    def test_too_many_values_for_out_max(self):
+        with self.assertRaises(TypeError):
+            clamp = tio.ClampIntensity(out_max=(1, 2))
+            clamp(self.sample_subject)
+
+    def test_wrong_out_min_type(self):
+        with self.assertRaises(TypeError):
+            clamp = tio.ClampIntensity(out_min='foo')
+            clamp(self.sample_subject)
+
+    def test_wrong_out_max_type(self):
+        with self.assertRaises(TypeError):
+            clamp = tio.ClampIntensity(out_max='foo')
+            clamp(self.sample_subject)

--- a/torchio/transforms/__init__.py
+++ b/torchio/transforms/__init__.py
@@ -34,7 +34,7 @@ from .preprocessing import CopyAffine
 from .preprocessing import ToCanonical
 from .preprocessing import ZNormalization
 from .preprocessing import RescaleIntensity
-from .preprocessing import ClampIntensity
+from .preprocessing import Clamp
 from .preprocessing import Mask
 from .preprocessing import EnsureShapeMultiple
 from .preprocessing import HistogramStandardization
@@ -87,7 +87,7 @@ __all__ = [
     'ZNormalization',
     'HistogramStandardization',
     'RescaleIntensity',
-    'ClampIntensity',
+    'Clamp',
     'Mask',
     'CropOrPad',
     'CopyAffine',

--- a/torchio/transforms/__init__.py
+++ b/torchio/transforms/__init__.py
@@ -34,6 +34,7 @@ from .preprocessing import CopyAffine
 from .preprocessing import ToCanonical
 from .preprocessing import ZNormalization
 from .preprocessing import RescaleIntensity
+from .preprocessing import ClampIntensity
 from .preprocessing import Mask
 from .preprocessing import EnsureShapeMultiple
 from .preprocessing import HistogramStandardization
@@ -86,6 +87,7 @@ __all__ = [
     'ZNormalization',
     'HistogramStandardization',
     'RescaleIntensity',
+    'ClampIntensity',
     'Mask',
     'CropOrPad',
     'CopyAffine',

--- a/torchio/transforms/preprocessing/__init__.py
+++ b/torchio/transforms/preprocessing/__init__.py
@@ -8,6 +8,7 @@ from .spatial.ensure_shape_multiple import EnsureShapeMultiple
 
 from .intensity.mask import Mask
 from .intensity.rescale import RescaleIntensity
+from .intensity.clamp import ClampIntensity
 from .intensity.z_normalization import ZNormalization
 from .intensity.histogram_standardization import HistogramStandardization
 
@@ -29,6 +30,7 @@ __all__ = [
     'EnsureShapeMultiple',
     'Mask',
     'RescaleIntensity',
+    'ClampIntensity',
     'ZNormalization',
     'HistogramStandardization',
     'OneHot',

--- a/torchio/transforms/preprocessing/__init__.py
+++ b/torchio/transforms/preprocessing/__init__.py
@@ -8,7 +8,7 @@ from .spatial.ensure_shape_multiple import EnsureShapeMultiple
 
 from .intensity.mask import Mask
 from .intensity.rescale import RescaleIntensity
-from .intensity.clamp import ClampIntensity
+from .intensity.clamp import Clamp
 from .intensity.z_normalization import ZNormalization
 from .intensity.histogram_standardization import HistogramStandardization
 
@@ -30,7 +30,7 @@ __all__ = [
     'EnsureShapeMultiple',
     'Mask',
     'RescaleIntensity',
-    'ClampIntensity',
+    'Clamp',
     'ZNormalization',
     'HistogramStandardization',
     'OneHot',

--- a/torchio/transforms/preprocessing/intensity/clamp.py
+++ b/torchio/transforms/preprocessing/intensity/clamp.py
@@ -1,20 +1,21 @@
+from torchio.data.image import ScalarImage
 from typing import Optional
 import torch
 from ....data.subject import Subject
-from .normalization_transform import NormalizationTransform
+from ...intensity_transform import IntensityTransform
 
 
-class ClampIntensity(NormalizationTransform):
+class Clamp(IntensityTransform):
     """Clamp intensity values to a certain range.
     Args:
-        out_min: See :func:`~torch.clamp`.
-        out_max: See :func:`~torch.clamp`.
+        out_min: See :func:`torch.clamp`.
+        out_max: See :func:`torch.clamp`.
 
     Example:
         >>> import torchio as tio
         >>> ct = tio.ScalarImage('ct_scan.nii.gz')
         >>> ct_air, ct_bone = -1000, 1000
-        >>> clamp = tio.ClampIntensity(out_min=ct_air, out_max=ct_bone)
+        >>> clamp = tio.Clamp(out_min=ct_air, out_max=ct_bone)
         >>> ct_clamped = clamp(ct)
     """
     def __init__(
@@ -26,18 +27,13 @@ class ClampIntensity(NormalizationTransform):
         super().__init__(**kwargs)
         self.out_min, self.out_max = out_min, out_max
 
-    def apply_normalization(
-            self,
-            subject: Subject,
-            image_name: str,
-            mask: torch.Tensor,
-            ) -> None:
-        image = subject[image_name]
-        image.set_data(self.clamp(image.data, image_name))
+    def apply_transform(self, subject: Subject) -> Subject:
+        for image in self.get_images(subject):
+            self.apply_clamp(image)
+        return subject
 
-    def clamp(
-            self,
-            tensor: torch.Tensor,
-            image_name: str,
-            ) -> torch.Tensor:
+    def apply_clamp(self, image: ScalarImage):
+        image.set_data(self.clamp(image.data))
+
+    def clamp(self, tensor: torch.Tensor) -> torch.Tensor:
         return tensor.clamp(self.out_min, self.out_max)

--- a/torchio/transforms/preprocessing/intensity/clamp.py
+++ b/torchio/transforms/preprocessing/intensity/clamp.py
@@ -27,13 +27,6 @@ class Clamp(IntensityTransform):
         super().__init__(**kwargs)
         self.out_min, self.out_max = out_min, out_max
 
-    def __repr__(self):
-        string = (
-            f'{self.__class__.__name__}'
-            f'(out_min={self.out_min}, out_max={self.out_max})'
-        )
-        return string
-
     def apply_transform(self, subject: Subject) -> Subject:
         for image in self.get_images(subject):
             self.apply_clamp(image)

--- a/torchio/transforms/preprocessing/intensity/clamp.py
+++ b/torchio/transforms/preprocessing/intensity/clamp.py
@@ -27,6 +27,13 @@ class Clamp(IntensityTransform):
         super().__init__(**kwargs)
         self.out_min, self.out_max = out_min, out_max
 
+    def __repr__(self):
+        string = (
+            f'{self.__class__.__name__}'
+            f'(out_min={self.out_min}, out_max={self.out_max})'
+        )
+        return string
+
     def apply_transform(self, subject: Subject) -> Subject:
         for image in self.get_images(subject):
             self.apply_clamp(image)

--- a/torchio/transforms/preprocessing/intensity/clamp.py
+++ b/torchio/transforms/preprocessing/intensity/clamp.py
@@ -6,16 +6,21 @@ from ...intensity_transform import IntensityTransform
 
 
 class Clamp(IntensityTransform):
-    """Clamp intensity values to a certain range.
+    """Clamp intensity values into a range :math:`[a, b]`.
+
+    For more information, see :func:`torch.clamp`.
+
     Args:
-        out_min: See :func:`torch.clamp`.
-        out_max: See :func:`torch.clamp`.
+        out_min: Minimum value :math:`a` of the output image. If ``None``, the
+            minimum of the image is used.
+        out_max: Maximum value :math:`b` of the output image. If ``None``, the
+            maximum of the image is used.
 
     Example:
         >>> import torchio as tio
         >>> ct = tio.ScalarImage('ct_scan.nii.gz')
-        >>> ct_air, ct_bone = -1000, 1000
-        >>> clamp = tio.Clamp(out_min=ct_air, out_max=ct_bone)
+        >>> HOUNSFIELD_AIR, HOUNSFIELD_BONE = -1000, 1000
+        >>> clamp = tio.Clamp(out_min=HOUNSFIELD_AIR, out_max=HOUNSFIELD_BONE)
         >>> ct_clamped = clamp(ct)
     """
     def __init__(
@@ -26,13 +31,14 @@ class Clamp(IntensityTransform):
             ):
         super().__init__(**kwargs)
         self.out_min, self.out_max = out_min, out_max
+        self.args_names = 'out_min', 'out_max'
 
     def apply_transform(self, subject: Subject) -> Subject:
         for image in self.get_images(subject):
             self.apply_clamp(image)
         return subject
 
-    def apply_clamp(self, image: ScalarImage):
+    def apply_clamp(self, image: ScalarImage) -> None:
         image.set_data(self.clamp(image.data))
 
     def clamp(self, tensor: torch.Tensor) -> torch.Tensor:

--- a/torchio/transforms/preprocessing/intensity/clamp.py
+++ b/torchio/transforms/preprocessing/intensity/clamp.py
@@ -1,0 +1,43 @@
+from typing import Optional
+import torch
+from ....data.subject import Subject
+from .normalization_transform import NormalizationTransform
+
+
+class ClampIntensity(NormalizationTransform):
+    """Clamp intensity values to a certain range.
+    Args:
+        out_min: See :func:`~torch.clamp`.
+        out_max: See :func:`~torch.clamp`.
+
+    Example:
+        >>> import torchio as tio
+        >>> ct = tio.ScalarImage('ct_scan.nii.gz')
+        >>> ct_air, ct_bone = -1000, 1000
+        >>> clamp = tio.ClampIntensity(out_min=ct_air, out_max=ct_bone)
+        >>> ct_clamped = clamp(ct)
+    """
+    def __init__(
+            self,
+            out_min: Optional[float] = None,
+            out_max: Optional[float] = None,
+            **kwargs
+            ):
+        super().__init__(**kwargs)
+        self.out_min, self.out_max = out_min, out_max
+
+    def apply_normalization(
+            self,
+            subject: Subject,
+            image_name: str,
+            mask: torch.Tensor,
+            ) -> None:
+        image = subject[image_name]
+        image.set_data(self.clamp(image.data, image_name))
+
+    def clamp(
+            self,
+            tensor: torch.Tensor,
+            image_name: str,
+            ) -> torch.Tensor:
+        return tensor.clamp(self.out_min, self.out_max)


### PR DESCRIPTION
Fixes #347.

**Description**
Added `torchio.ClampIntensity()` transform according to discussions in #347 and #348. I chose to use the word "clamp" to be consistent with `torch.clamp` terminology (which is also the underlying implementation), but this can be changed according to your preference (e.g. clipping).

Added tests and all tests passed locally.

**Checklist**
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
