### PR TITLE
Fix default pad value for label maps

### DIFF
--- a/tests/transforms/augmentation/test_random_affine.py
+++ b/tests/transforms/augmentation/test_random_affine.py
@@ -1,4 +1,5 @@
-from torchio.transforms import RandomAffine
+import torch
+import torchio as tio
 from ...utils import TorchioTestCase
 
 
@@ -12,7 +13,7 @@ class TestRandomAffine(TorchioTestCase):
 
     def test_rotation_image(self):
         # Rotation around image center
-        transform = RandomAffine(
+        transform = tio.RandomAffine(
             degrees=(90, 90),
             default_pad_value=0,
             center='image',
@@ -23,7 +24,7 @@ class TestRandomAffine(TorchioTestCase):
 
     def test_rotation_origin(self):
         # Rotation around far away point, image should be empty
-        transform = RandomAffine(
+        transform = tio.RandomAffine(
             degrees=(90, 90),
             default_pad_value=0,
             center='origin',
@@ -33,7 +34,7 @@ class TestRandomAffine(TorchioTestCase):
         self.assertEqual(total, 0)
 
     def test_no_rotation(self):
-        transform = RandomAffine(
+        transform = tio.RandomAffine(
             scales=(1, 1),
             degrees=(0, 0),
             default_pad_value=0,
@@ -45,7 +46,7 @@ class TestRandomAffine(TorchioTestCase):
             transformed.t1.data,
         )
 
-        transform = RandomAffine(
+        transform = tio.RandomAffine(
             scales=(1, 1),
             degrees=(180, 180),
             default_pad_value=0,
@@ -59,20 +60,20 @@ class TestRandomAffine(TorchioTestCase):
         )
 
     def test_isotropic(self):
-        RandomAffine(isotropic=True)(self.sample_subject)
+        tio.RandomAffine(isotropic=True)(self.sample_subject)
 
     def test_mean(self):
-        RandomAffine(default_pad_value='mean')(self.sample_subject)
+        tio.RandomAffine(default_pad_value='mean')(self.sample_subject)
 
     def test_otsu(self):
-        RandomAffine(default_pad_value='otsu')(self.sample_subject)
+        tio.RandomAffine(default_pad_value='otsu')(self.sample_subject)
 
     def test_bad_center(self):
         with self.assertRaises(ValueError):
-            RandomAffine(center='bad')
+            tio.RandomAffine(center='bad')
 
     def test_translation(self):
-        transform = RandomAffine(
+        transform = tio.RandomAffine(
             scales=(1, 1),
             degrees=0,
             translation=(5, 5)
@@ -93,72 +94,80 @@ class TestRandomAffine(TorchioTestCase):
 
     def test_negative_scales(self):
         with self.assertRaises(ValueError):
-            RandomAffine(scales=(-1, 1))
+            tio.RandomAffine(scales=(-1, 1))
 
     def test_scale_too_large(self):
         with self.assertRaises(ValueError):
-            RandomAffine(scales=1.5)
+            tio.RandomAffine(scales=1.5)
 
     def test_scales_range_with_negative_min(self):
         with self.assertRaises(ValueError):
-            RandomAffine(scales=(-1, 4))
+            tio.RandomAffine(scales=(-1, 4))
 
     def test_wrong_scales_type(self):
         with self.assertRaises(ValueError):
-            RandomAffine(scales='wrong')
+            tio.RandomAffine(scales='wrong')
 
     def test_wrong_degrees_type(self):
         with self.assertRaises(ValueError):
-            RandomAffine(degrees='wrong')
+            tio.RandomAffine(degrees='wrong')
 
     def test_too_many_translation_values(self):
         with self.assertRaises(ValueError):
-            RandomAffine(translation=(-10, 4, 42))
+            tio.RandomAffine(translation=(-10, 4, 42))
 
     def test_wrong_translation_type(self):
         with self.assertRaises(ValueError):
-            RandomAffine(translation='wrong')
+            tio.RandomAffine(translation='wrong')
 
     def test_wrong_center(self):
         with self.assertRaises(ValueError):
-            RandomAffine(center=0)
+            tio.RandomAffine(center=0)
 
     def test_wrong_default_pad_value(self):
         with self.assertRaises(ValueError):
-            RandomAffine(default_pad_value='wrong')
+            tio.RandomAffine(default_pad_value='wrong')
 
     def test_wrong_image_interpolation_type(self):
         with self.assertRaises(TypeError):
-            RandomAffine(image_interpolation=0)
+            tio.RandomAffine(image_interpolation=0)
 
     def test_wrong_image_interpolation_value(self):
         with self.assertRaises(ValueError):
-            RandomAffine(image_interpolation='wrong')
+            tio.RandomAffine(image_interpolation='wrong')
 
     def test_incompatible_args_isotropic(self):
         with self.assertRaises(ValueError):
-            RandomAffine(scales=(0.8, 0.5, 0.1), isotropic=True)
+            tio.RandomAffine(scales=(0.8, 0.5, 0.1), isotropic=True)
 
     def test_parse_scales(self):
         def do_assert(transform):
             self.assertEqual(transform.scales, 3 * (0.9, 1.1))
-        do_assert(RandomAffine(scales=0.1))
-        do_assert(RandomAffine(scales=(0.9, 1.1)))
-        do_assert(RandomAffine(scales=3 * (0.1,)))
-        do_assert(RandomAffine(scales=3 * [0.9, 1.1]))
+        do_assert(tio.RandomAffine(scales=0.1))
+        do_assert(tio.RandomAffine(scales=(0.9, 1.1)))
+        do_assert(tio.RandomAffine(scales=3 * (0.1,)))
+        do_assert(tio.RandomAffine(scales=3 * [0.9, 1.1]))
 
     def test_parse_degrees(self):
         def do_assert(transform):
             self.assertEqual(transform.degrees, 3 * (-10, 10))
-        do_assert(RandomAffine(degrees=10))
-        do_assert(RandomAffine(degrees=(-10, 10)))
-        do_assert(RandomAffine(degrees=3 * (10,)))
-        do_assert(RandomAffine(degrees=3 * [-10, 10]))
+        do_assert(tio.RandomAffine(degrees=10))
+        do_assert(tio.RandomAffine(degrees=(-10, 10)))
+        do_assert(tio.RandomAffine(degrees=3 * (10,)))
+        do_assert(tio.RandomAffine(degrees=3 * [-10, 10]))
 
     def test_parse_translation(self):
         def do_assert(transform):
             self.assertEqual(transform.translation, 3 * (-10, 10))
-        do_assert(RandomAffine(translation=10))
-        do_assert(RandomAffine(translation=(-10, 10)))
-        do_assert(RandomAffine(translation=3 * (10,)))
-        do_assert(RandomAffine(translation=3 * [-10, 10]))
+        do_assert(tio.RandomAffine(translation=10))
+        do_assert(tio.RandomAffine(translation=(-10, 10)))
+        do_assert(tio.RandomAffine(translation=3 * (10,)))
+        do_assert(tio.RandomAffine(translation=3 * [-10, 10]))
+
+    def test_default_value_label_map(self):
+        # From https://github.com/fepegar/torchio/issues/626
+        a = torch.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]]).reshape(1, 3, 3, 1)
+        image = tio.LabelMap(tensor=a)
+        aff = tio.RandomAffine(translation=(0, 1, 1), default_pad_value='otsu')
+        transformed = aff(image)
+        assert all(n in (0, 1) for n in transformed.data.flatten())


### PR DESCRIPTION
Fixes #626.

**Description**
If the Otsu technique is used to compute the default padding value for the affine augmentation, it should only be used for scalar images, as noted by @glupol in #626.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
