### PR TITLE
Fix syntax error for Python < 3.8

### DIFF
--- a/torchio/data/io.py
+++ b/torchio/data/io.py
@@ -79,7 +79,7 @@ def read_shape(path: TypePath) -> Tuple[int, int, int, int]:
     spatial_shape = reader.GetSize()
     if reader.GetDimension() == 2:
         spatial_shape = *spatial_shape, 1
-    return num_channels, *spatial_shape
+    return (num_channels,) + spatial_shape
 
 
 def read_affine(path: TypePath) -> np.ndarray:


### PR DESCRIPTION
**Description**
The lazy-loading features added recently broke the CI for Python<3.8. This commit makes the code compatible with older Python versions.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
