### PR TITLE
Fix single slices metadata being lost

### DIFF
--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -349,7 +349,7 @@ class Image(dict):
         elif axis == 'P': flipped_axis = 'A'
         elif axis == 'I': flipped_axis = 'S'
         elif axis == 'S': flipped_axis = 'I'
-        elif axis == 'T': flipped_axis = 'B'
+        elif axis == 'T': flipped_axis = 'B'  # top / bottom
         elif axis == 'B': flipped_axis = 'T'
         else:
             values = ', '.join('LRPAISTB')
@@ -495,13 +495,14 @@ class Image(dict):
             warnings.warn(f'NaNs found in file "{path}"', RuntimeWarning)
         return tensor, affine
 
-    def save(self, path: TypePath, squeeze: bool = True) -> None:
+    def save(self, path: TypePath, squeeze: Optional[bool] = None) -> None:
         """Save image to disk.
 
         Args:
             path: String or instance of :class:`pathlib.Path`.
-            squeeze: If ``True``, singleton dimensions will be removed
-                before saving.
+            squeeze: Whether to remove singleton dimensions before saving.
+                If ``None``, the array will be squeezed if the output format is
+                JP(E)G, PNG, BMP or TIF(F).
         """
         write_image(
             self.data,


### PR DESCRIPTION
**Description**
As reported by @OeslleLucena, part of the images' metadata was lost when saving, due to the data being squeezed and SimpleITK ignoring the 3rd dimension.

Test snippet:

```python
import torchio as tio
im = tio.ScalarImage('/tmp/t1.nii.gz')
slice = tio.CropOrPad((256, 256, 1))(im)
slice.save('/tmp/slice.nii.gz')
```

Before (incorrect):

```python
In [2]: tio.ScalarImage('/tmp/slice.nii.gz').origin
Out[2]: (5.31927490234375, 132.3373565673828, 0.0)
```

Now (correct):

```python
In [2]: tio.ScalarImage('/tmp/slice.nii.gz').origin
Out[2]: (5.31927490234375, 132.3373565673828, 102.21686553955078)
```

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
