### PR TITLE
Add Resize transform

### DIFF
--- a/docs/source/transforms/preprocessing.rst
+++ b/docs/source/transforms/preprocessing.rst
@@ -86,6 +86,13 @@ Spatial
     :show-inheritance:
 
 
+:class:`Resize`
+~~~~~~~~~~~~~~~
+
+.. autoclass:: Resize
+    :show-inheritance:
+
+
 :class:`EnsureShapeMultiple`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/transforms/preprocessing/test_resize.py
+++ b/tests/transforms/preprocessing/test_resize.py
@@ -1,3 +1,5 @@
+import torch
+import numpy as np
 import torchio as tio
 from ...utils import TorchioTestCase
 
@@ -17,3 +19,13 @@ class TestResize(TorchioTestCase):
         transformed = transform(self.sample_subject)
         for image in transformed.get_images(intensity_only=False):
             self.assertEqual(image.spatial_shape, target_shape)
+
+    def test_fix_shape(self):
+        # We use values that are known to need cropping
+        tensor = torch.rand(1, 8, 180, 320)
+        affine = np.diag((5, 1, 1, 1))
+        im = tio.ScalarImage(tensor=tensor, affine=affine)
+        target = 12
+        with self.assertWarns(UserWarning):
+            result = tio.Resize(target)(im)
+        self.assertEqual(result.spatial_shape, 3 * (target,))

--- a/tests/transforms/preprocessing/test_resize.py
+++ b/tests/transforms/preprocessing/test_resize.py
@@ -1,0 +1,19 @@
+import torchio as tio
+from ...utils import TorchioTestCase
+
+
+class TestResize(TorchioTestCase):
+    """Tests for `Resize`."""
+    def test_one_dim(self):
+        target_shape = 5
+        transform = tio.Resize(target_shape)
+        transformed = transform(self.sample_subject)
+        for image in transformed.get_images(intensity_only=False):
+            self.assertEqual(image.spatial_shape, 3 * (target_shape,))
+
+    def test_all_dims(self):
+        target_shape = 11, 6, 7
+        transform = tio.Resize(target_shape)
+        transformed = transform(self.sample_subject)
+        for image in transformed.get_images(intensity_only=False):
+            self.assertEqual(image.spatial_shape, target_shape)

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -17,6 +17,7 @@ class TestTransforms(TorchioTestCase):
         disp = 1 if is_3d else (1, 1, 0.01)
         elastic = tio.RandomElasticDeformation(max_displacement=disp)
         cp_args = (9, 21, 30) if is_3d else (21, 30, 1)
+        resize_args = (10, 20, 30) if is_3d else (10, 20, 1)
         flip_axes = axes_downsample = (0, 1, 2) if is_3d else (0, 1)
         swap_patch = (2, 3, 4) if is_3d else (3, 4, 1)
         pad_args = (1, 2, 3, 0, 5, 6) if is_3d else (0, 0, 3, 0, 5, 6)
@@ -24,9 +25,10 @@ class TestTransforms(TorchioTestCase):
         remapping = {1: 2, 2: 1, 3: 20, 4: 25}
         transforms = [
             tio.CropOrPad(cp_args),
+            tio.EnsureShapeMultiple(2, method='crop'),
+            tio.Resize(resize_args),
             tio.ToCanonical(),
             tio.RandomAnisotropy(downsampling=(1.75, 2), axes=axes_downsample),
-            tio.EnsureShapeMultiple(2, method='crop'),
             tio.CopyAffine(channels[0]),
             tio.Resample((1, 1.1, 1.25)),
             tio.RandomFlip(axes=flip_axes, flip_probability=1),

--- a/torchio/transforms/__init__.py
+++ b/torchio/transforms/__init__.py
@@ -28,6 +28,7 @@ from .augmentation.intensity import RandomLabelsToImage, LabelsToImage
 # Preprocessing
 from .preprocessing import Pad
 from .preprocessing import Crop
+from .preprocessing import Resize
 from .preprocessing import Resample
 from .preprocessing import CropOrPad
 from .preprocessing import CopyAffine
@@ -82,6 +83,7 @@ __all__ = [
     'LabelsToImage',
     'Pad',
     'Crop',
+    'Resize',
     'Resample',
     'ToCanonical',
     'ZNormalization',

--- a/torchio/transforms/preprocessing/__init__.py
+++ b/torchio/transforms/preprocessing/__init__.py
@@ -1,5 +1,6 @@
 from .spatial.pad import Pad
 from .spatial.crop import Crop
+from .spatial.resize import Resize
 from .spatial.resample import Resample
 from .spatial.crop_or_pad import CropOrPad
 from .spatial.to_canonical import ToCanonical
@@ -23,6 +24,7 @@ from .label.keep_largest_component import KeepLargestComponent
 __all__ = [
     'Pad',
     'Crop',
+    'Resize',
     'Resample',
     'ToCanonical',
     'CropOrPad',

--- a/torchio/transforms/preprocessing/spatial/crop_or_pad.py
+++ b/torchio/transforms/preprocessing/spatial/crop_or_pad.py
@@ -11,7 +11,7 @@ from ....data.subject import Subject
 
 
 class CropOrPad(BoundsTransform):
-    """Crop and/or pad an image to a target shape.
+    """Modify the field of view by cropping or padding to match a target shape.
 
     This transform modifies the affine matrix associated to the volume so that
     physical positions of the voxels are maintained.

--- a/torchio/transforms/preprocessing/spatial/resize.py
+++ b/torchio/transforms/preprocessing/spatial/resize.py
@@ -1,0 +1,58 @@
+import warnings
+
+import numpy as np
+
+from ....utils import to_tuple
+from ....data.subject import Subject
+from ....typing import TypeSpatialShape
+from ... import SpatialTransform
+from .resample import Resample
+from .crop_or_pad import CropOrPad
+
+
+class Resize(SpatialTransform):
+    """Resample images so the output shape matches the given target shape.
+
+    The field of view remains the same.
+
+    Args:
+        target_shape: Tuple :math:`(W, H, D)`. If a single value :math:`N` is
+            provided, then :math:`W = H = D = N`.
+        image_interpolation: See :ref:`Interpolation`.
+    """
+    def __init__(
+            self,
+            target_shape: TypeSpatialShape,
+            image_interpolation: str = 'linear',
+            **kwargs
+            ):
+        super().__init__(**kwargs)
+        self.target_shape = np.asarray(to_tuple(target_shape, length=3))
+        self.image_interpolation = self.parse_interpolation(
+            image_interpolation)
+        self.args_names = (
+            'target_shape',
+            'image_interpolation',
+        )
+
+    def apply_transform(self, subject: Subject) -> Subject:
+        shape_in = np.asarray(subject.spatial_shape)
+        shape_out = self.target_shape
+        spacing_in = np.asarray(subject.spacing)
+        spacing_out = shape_in / shape_out * spacing_in
+        resample = Resample(
+            spacing_out,
+            image_interpolation=self.image_interpolation,
+        )
+        resampled = resample(subject)
+        # Sometimes, the output shape is one voxel too large
+        # Probably because Resample uses np.ceil to compute the shape
+        if not resampled.spatial_shape == tuple(shape_out):
+            message = (
+                f'Output shape {resampled.spatial_shape}'
+                f' != target shape {tuple(shape_out)}. Fixing with CropOrPad'
+            )
+            warnings.warn(message)
+            crop_pad = CropOrPad(shape_out)
+            resampled = crop_pad(resampled)
+        return resampled


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Resolves #45.
Related to #193, #205, #215.

**Description**
This transform is useful for situations in which we don't mind changing the aspect ratio of the object and want to keep the field of view constant. This happens often in computer vision applications. For example, I am using this transform on videos.

```python
In [1]: !curl -o person.jpg https://thispersondoesnotexist.com/image
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  398k  100  398k    0     0  1726k      0 --:--:-- --:--:-- --:--:-- 1726k

In [4]: im = tio.ScalarImage('person.jpg')

In [5]: im.plot()
```

![person](https://user-images.githubusercontent.com/12688084/131720086-d70402e2-a415-4c88-8595-b0659a5af99f.jpg)

```python
In [6]: im.shape
Out[6]: (3, 1024, 1024, 1)

In [7]: im = tio.Crop((100, 0, 0))(im)  # simulate a rectangular image

In [8]: im.shape
Out[8]: (3, 824, 1024, 1)

In [9]: im.plot()
```

![person1](https://user-images.githubusercontent.com/12688084/131720137-1aa22ba6-36b0-451a-81b2-1f843167aded.jpg)

```python
In [13]: resize = tio.Resize((224, 224, 1))

In [14]: resized = resize(im)

In [15]: resized.shape
Out[15]: (3, 224, 224, 1)

In [16]: resized.plot()
```

![person2](https://user-images.githubusercontent.com/12688084/131720315-bf16b28d-f7f7-4310-b5a2-23740f9d4218.jpg)

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
