### PR TITLE
Raise from None to reduce error verbosity

### DIFF
--- a/torchio/data/subject.py
+++ b/torchio/data/subject.py
@@ -290,7 +290,7 @@ class Subject(dict):
             num_unique_values = len(set(values_dict.values()))
             if num_unique_values > 1:
                 message = message.format(pprint.pformat(values_dict))
-                raise RuntimeError(message)
+                raise RuntimeError(message) from None
 
     def check_consistent_spatial_shape(self) -> None:
         self.check_consistent_attribute('spatial_shape')


### PR DESCRIPTION
Fixes #648.

New behavior (compared to #648):

```python-traceback
In [1]: import torchio as tio
   ...: fpg = tio.datasets.FPG()
   ...: fpg.check_consistent_orientation()
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-1-70e655305e32> in <module>
      1 import torchio as tio
      2 fpg = tio.datasets.FPG()
----> 3 fpg.check_consistent_orientation()

~/git/torchio/torchio/data/subject.py in check_consistent_orientation(self)
    297
    298     def check_consistent_orientation(self) -> None:
--> 299         self.check_consistent_attribute('orientation')
    300
    301     def check_consistent_affine(self) -> None:

~/git/torchio/torchio/data/subject.py in check_consistent_attribute(self, attribute, relative_tolerance, absolute_tolerance, message)
    291             if num_unique_values > 1:
    292                 message = message.format(pprint.pformat(values_dict))
--> 293                 raise RuntimeError(message) from None
    294
    295     def check_consistent_spatial_shape(self) -> None:

RuntimeError: More than one value for "orientation" found in subject images:
{'dmri': ('L', 'A', 'S'),
 'fmri': ('L', 'A', 'S'),
 'seg': ('P', 'I', 'R'),
 't1': ('P', 'I', 'R'),
 't2': ('L', 'A', 'S')}
```