### PR TITLE
Fix visualization for subject with many images

### DIFF
--- a/torchio/visualization.py
+++ b/torchio/visualization.py
@@ -110,16 +110,16 @@ def plot_subject(
         **kwargs,
         ):
     _, plt = import_mpl_plt()
+    num_images = len(subject)
+    many_images = num_images > 2
     subplots_kwargs = {'figsize': figsize}
     try:
         if clear_axes:
             subject.check_consistent_spatial_shape()
-            subplots_kwargs['sharex'] = 'col'
-            subplots_kwargs['sharey'] = 'col'
+            subplots_kwargs['sharex'] = 'row' if many_images else 'col'
+            subplots_kwargs['sharey'] = 'row' if many_images else 'col'
     except RuntimeError:  # different shapes in subject
         pass
-    num_images = len(subject)
-    many_images = num_images > 2
     args = (3, num_images) if many_images else (num_images, 3)
     fig, axes = plt.subplots(*args, **subplots_kwargs)
     # The array of axes must be 2D so that it can be indexed correctly within


### PR DESCRIPTION
As reported by @cepa995 in #652.

**Description**
Axis sharing was hard-coded to use columns, but rows are desired for subject with many images (>2):

```python
import torchio as tio
dataset = tio.datasets.RSNAMICCAI('root')
subject = dataset[0]  # it's subject 00792
transform = tio.Compose([
                tio.ToCanonical(),
                tio.Resample("T2w"),
                tio.RescaleIntensity((-1, 1)),
                tio.OneHot(),
            ])
transform(subject).plot()
```

Before:

![Figure_0](https://user-images.githubusercontent.com/12688084/132123103-d4641eba-17bc-4286-882d-f05de93dd09f.png)

After:

![Figure_1](https://user-images.githubusercontent.com/12688084/132123086-67699143-4e7a-4ee6-b56d-98c5845cb32d.png)

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
