### PR TITLE
Add support to save GIFs

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -201,3 +201,8 @@ class TestImage(TorchioTestCase):
         assert_shape((5, 5, 5), (1, 5, 5, 5))
         assert_shape((1, 5, 5, 5), (1, 5, 5, 5))
         assert_shape((4, 5, 5, 5), (4, 5, 5, 5))
+
+    def test_fast_gif(self):
+        with self.assertWarns(UserWarning):
+            with tempfile.NamedTemporaryFile(suffix='.gif') as f:
+                self.sample_subject.t1.to_gif(0, 0.0001, f.name)

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -206,3 +206,7 @@ class TestImage(TorchioTestCase):
         with self.assertWarns(UserWarning):
             with tempfile.NamedTemporaryFile(suffix='.gif') as f:
                 self.sample_subject.t1.to_gif(0, 0.0001, f.name)
+
+    def test_gif_rgb(self):
+        with tempfile.NamedTemporaryFile(suffix='.gif') as f:
+            tio.ScalarImage(tensor=torch.rand(3, 4, 5, 6)).to_gif(0, 1, f.name)

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -584,6 +584,43 @@ class Image(dict):
         array = tensor.clamp(0, 255).numpy()[0]
         return ImagePIL.fromarray(array.astype(np.uint8))
 
+    def to_gif(
+            self,
+            axis: int,
+            duration: float,  # of full gif
+            output_path: TypePath,
+            loop: int = 0,
+            rescale: bool = True,
+            optimize: bool = True,
+            reverse: bool = False,
+        ) -> None:
+        """Save an animated GIF of the image.
+
+        Args:
+            axis: Spatial axis (0, 1 or 2).
+            duration: Duration of the full animation in seconds.
+            output_path: Path to the output GIF file.
+            loop: Number of times the GIF should loop.
+                ``0`` means that it will loop forever.
+            rescale: Use :class:`~torchio.transforms.preprocessing.intensity.rescale.RescaleIntensity`
+                to rescale the intensity values to :math:`[0, 255]`.
+            optimize: If ``True``, attempt to compress the palette by
+                eliminating unused colors. This is only useful if the palette
+                can be compressed to the next smaller power of 2 elements.
+            reverse: Reverse the temporal order of frames.
+        """  # noqa: E501
+        from ..visualization import make_gif  # avoid circular import
+        make_gif(
+            self.data,
+            axis,
+            duration,
+            output_path,
+            loop=loop,
+            rescale=rescale,
+            optimize=optimize,
+            reverse=reverse,
+        )
+
     def get_center(self, lps: bool = False) -> TypeTripletFloat:
         """Get image center in RAS+ or LPS+ coordinates.
 


### PR DESCRIPTION
**Description**
Add support to save GIFs.

```python
import torchio as tio
tio.datasets.Colin27().t1.to_gif(1, 3, 'colin.gif', reverse=True)
```

![colinn](https://user-images.githubusercontent.com/12688084/135751924-f09c4826-2d38-4438-8653-905b21edca84.gif)

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [ ] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
