### PR TITLE
Add plot_volume indices parameter

### DIFF
--- a/torchio/visualization.py
+++ b/torchio/visualization.py
@@ -155,6 +155,7 @@ def plot_subject(
         fig.savefig(output_path)
     if show:
         plt.show()
+    plt.close(fig) 
 
 
 def color_labels(arrays, cmap_dict):

--- a/torchio/visualization.py
+++ b/torchio/visualization.py
@@ -39,6 +39,7 @@ def plot_volume(
         percentiles=(0.5, 99.5),
         figsize=None,
         reorient=True,
+        indices=None,
         ):
     _, plt = import_mpl_plt()
     fig = None
@@ -49,7 +50,8 @@ def plot_volume(
     if reorient:
         image = ToCanonical()(image)
     data = image.data[channel]
-    indices = np.array(data.shape) // 2
+    if indices is None:
+        indices = np.array(data.shape) // 2
     i, j, k = indices
     slice_x = rotate(data[i, :, :], radiological=radiological)
     slice_y = rotate(data[:, j, :], radiological=radiological)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes https://github.com/fepegar/torchio/discussions/681

**Description**
Two changes:
- Add plot_volume indices parameter that defaults to None
- Close figure window with `plt.close(figure_object)`  as described in [documentation](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.close.html) and described  [here](https://stackoverflow.com/questions/9622163/save-plot-to-image-file-instead-of-displaying-it-using-matplotlib).  Doing this because even when `show=True` the image would show and I don't have  lots of open figures during a loop.

**Checklist**

note done.
