### PR TITLE
Add indices parameter for plotting volumes

### DIFF
--- a/torchio/visualization.py
+++ b/torchio/visualization.py
@@ -155,6 +155,7 @@ def plot_subject(
         fig.savefig(output_path)
     if show:
         plt.show()
+    plt.close(fig) 
 
 
 def color_labels(arrays, cmap_dict):


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes https://github.com/fepegar/torchio/discussions/681

**Description**
Two changes:
- Add plot_volume indices parameter that defaults to None. This gives the option to plot things other than the middle slice of the MRI.

- Close figure window with `plt.close(figure_object)`  as described in [documentation](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.close.html) and described  [here](https://stackoverflow.com/questions/9622163/save-plot-to-image-file-instead-of-displaying-it-using-matplotlib).  Doing this because even when `show=True` the image would show and I don't want to have  lots of open figures during a loop.