### PR TITLE
Add parse_input kwarg to Transform

### DIFF
--- a/torchio/transforms/augmentation/composition.py
+++ b/torchio/transforms/augmentation/composition.py
@@ -23,7 +23,7 @@ class Compose(Transform):
 
     """
     def __init__(self, transforms: Sequence[Transform], **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(parse_input=False, **kwargs)
         for transform in transforms:
             if not callable(transform):
                 message = (
@@ -98,7 +98,7 @@ class OneOf(RandomTransform):
             transforms: TypeTransformsDict,
             **kwargs
             ):
-        super().__init__(**kwargs)
+        super().__init__(parse_input=False, **kwargs)
         self.transforms_dict = self._get_transforms_dict(transforms)
 
     def apply_transform(self, subject: Subject) -> Subject:


### PR DESCRIPTION
Fixes #695.

**Description**

1. Added the `parse_input` kwarg to `Transform`
2. Set this to `False` in `Compose` and `OneOf`
3. This should have happened in #642, and definitely not here, but added `Resize` to the list of transforms that don't need to be in the transforms history

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [ ] Non-breaking change (would not break existing functionality)
- [x] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
