### PR TITLE
Cast translation argument to float64 for SimpleITK

### DIFF
--- a/torchio/transforms/augmentation/spatial/random_affine.py
+++ b/torchio/transforms/augmentation/spatial/random_affine.py
@@ -248,6 +248,7 @@ class Affine(SpatialTransform):
         transform = sitk.Euler3DTransform()
         radians = np.radians(degrees)
         transform.SetRotation(*radians)
+        translation = np.array(translation).astype(float)
         transform.SetTranslation(translation)
         if center_lps is not None:
             transform.SetCenter(center_lps)


### PR DESCRIPTION
Fixes #701.

**Description**
SimpleITK throws a `TypeError` if the translation arguments have not `float` type. In this PR, the argument is cast before being passed to `SetTranslation`.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
