### PR TITLE
Add support to copy an object that inherits from `Subject`

### DIFF
--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -106,3 +106,14 @@ class TestSubject(TorchioTestCase):
     def test_no_images(self):
         with self.assertRaises(ValueError):
             tio.Subject(a=0)
+
+    def test_copy_subclass(self):
+        class CustomSubject(tio.Subject):
+            def __init__(self, img: tio.Image, *args, **kwargs):
+                kwargs['img'] = img
+                super().__init__(*args, **kwargs)
+
+        subject = CustomSubject(img=tio.ScalarImage(tensor=torch.rand(1, 3, 3, 4)))
+        new_subject = copy.copy(subject)
+
+        assert isinstance(new_subject, CustomSubject)

--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -112,8 +112,18 @@ class TestSubject(TorchioTestCase):
             def __init__(self, img: tio.Image, *args, **kwargs):
                 kwargs['img'] = img
                 super().__init__(*args, **kwargs)
-
-        subject = CustomSubject(img=tio.ScalarImage(tensor=torch.rand(1, 3, 3, 4)))
+        tensor = torch.rand(1, 3, 3, 4)
+        subject = CustomSubject(img=tio.ScalarImage(tensor=tensor))
         new_subject = copy.copy(subject)
+        assert isinstance(new_subject, CustomSubject)
 
+    def test_copy_subclass_no_kwargs(self):
+        class CustomSubject(tio.Subject):
+            def __init__(self):
+                tensor = torch.rand(1, 3, 3, 4)
+                img = tio.ScalarImage(tensor=tensor)
+                kwargs = {'img': img}
+                super().__init__(**kwargs)
+        subject = CustomSubject()
+        new_subject = copy.copy(subject)
         assert isinstance(new_subject, CustomSubject)

--- a/torchio/data/subject.py
+++ b/torchio/data/subject.py
@@ -71,7 +71,7 @@ class Subject(dict):
             else:
                 value = copy.deepcopy(value)
             result_dict[key] = value
-        new = Subject(result_dict)
+        new = self.__class__(**result_dict)
         new.applied_transforms = self.applied_transforms[:]
         return new
 


### PR DESCRIPTION
Fixes #694.

**Description**
use of __class__ in __copy__ method of subject to make subclass Subject possible

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
