### PR TITLE
Minor quality of life functions for inspecting scalar images and label maps

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -213,3 +213,17 @@ class TestImage(TorchioTestCase):
     def test_gif_rgb(self):
         with tempfile.NamedTemporaryFile(suffix='.gif', delete=False) as f:
             tio.ScalarImage(tensor=torch.rand(3, 4, 5, 6)).to_gif(0, 1, f.name)
+
+    def test_hist(self):
+        self.sample_subject.t1.hist(density=False, show=False)
+        self.sample_subject.t1.hist(density=True, show=False)
+
+    def test_count(self):
+        image = self.sample_subject.label
+        max_n = image.data.numel()
+        nonzero = image.count_nonzero()
+        assert 0 <= nonzero <= max_n
+        counts = image.count_labels()
+        assert tuple(counts) == (0, 1)
+        assert 0 <= counts[0] <= max_n
+        assert 0 <= counts[1] <= max_n

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -677,6 +677,13 @@ class ScalarImage(Image):
         super().__init__(*args, **kwargs)
 
 
+    def hist(self, **kwargs) -> None:
+        """Plot histogram."""
+        from ..visualization import plot_histogram
+        x = self.data.flatten().numpy()
+        plot_histogram(x, **kwargs)
+
+
 class LabelMap(Image):
     """Image whose pixel values represent categorical labels.
 
@@ -704,3 +711,11 @@ class LabelMap(Image):
             raise ValueError('Type of LabelMap is always torchio.LABEL')
         kwargs.update({'type': LABEL})
         super().__init__(*args, **kwargs)
+
+    def count_nonzero(self) -> int:
+        return int(self.data.count_nonzero())
+
+    def count_labels(self) -> dict:
+        counts = self.data.unique(return_counts=True)
+        counts_dict = {int(l):int(c) for l,c in zip(counts[0], counts[1])}
+        return counts_dict

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -1,5 +1,6 @@
 import warnings
 from pathlib import Path
+from collections import Counter
 from collections.abc import Iterable
 from typing import Any, Dict, Tuple, Optional, Union, Sequence, List, Callable
 
@@ -676,7 +677,6 @@ class ScalarImage(Image):
         kwargs.update({'type': INTENSITY})
         super().__init__(*args, **kwargs)
 
-
     def hist(self, **kwargs) -> None:
         """Plot histogram."""
         from ..visualization import plot_histogram
@@ -713,9 +713,12 @@ class LabelMap(Image):
         super().__init__(*args, **kwargs)
 
     def count_nonzero(self) -> int:
-        return int(self.data.count_nonzero())
+        """Get the number of voxels that are not 0."""
+        return self.data.count_nonzero().item()
 
-    def count_labels(self) -> dict:
-        counts = self.data.unique(return_counts=True)
-        counts_dict = {int(l):int(c) for l,c in zip(counts[0], counts[1])}
-        return counts_dict
+    def count_labels(self) -> Dict[int, int]:
+        """Get the number of voxels in each label."""
+        values_list = self.data.flatten().tolist()
+        counter = Counter(values_list)
+        counts = {label: counter[label] for label in sorted(counter)}
+        return counts

--- a/torchio/visualization.py
+++ b/torchio/visualization.py
@@ -158,7 +158,17 @@ def plot_subject(
     plt.close(fig)
 
 
-def num_bins(x: np.ndarray) -> int:
+def get_num_bins(x: np.ndarray) -> int:
+    """Get the optimal number of bins for a histogram.
+
+    This method uses the Freedman–Diaconis rule to compute the histogram that
+    minimizes "the integral of the squared difference between the histogram
+    (i.e., relative frequency density) and the density of the theoretical
+    probability distribution" (`Wikipedia <https://en.wikipedia.org/wiki/Freedman%E2%80%93Diaconis_rule>`_).
+
+    Args:
+        x: Input values.
+    """  # noqa: E501
     # Freedman–Diaconis number of bins
     q25, q75 = np.percentile(x, [25, 75])
     bin_width = 2 * (q75 - q25) * len(x) ** (-1 / 3)
@@ -166,16 +176,15 @@ def num_bins(x: np.ndarray) -> int:
     return bins
 
 
-def plot_histogram(x: np.ndarray, **kwargs) -> None:
+def plot_histogram(x: np.ndarray, show=True, **kwargs) -> None:
     _, plt = import_mpl_plt()
-    plt.hist(x, bins=num_bins(x), **kwargs)
+    plt.hist(x, bins=get_num_bins(x), **kwargs)
     plt.xlabel('Intensity')
     density = kwargs.pop('density', False)
-    if density:
-        plt.ylabel('Density')
-    else:
-        plt.ylabel('Frequency')
-    plt.show()
+    ylabel = 'Density' if density else 'Frequency'
+    plt.ylabel(ylabel)
+    if show:
+        plt.show()
 
 
 def color_labels(arrays, cmap_dict):

--- a/torchio/visualization.py
+++ b/torchio/visualization.py
@@ -158,6 +158,26 @@ def plot_subject(
     plt.close(fig)
 
 
+def num_bins(x: np.ndarray) -> int:
+    # Freedman–Diaconis number of bins
+    q25, q75 = np.percentile(x, [25, 75])
+    bin_width = 2 * (q75 - q25) * len(x) ** (-1 / 3)
+    bins = round((x.max() - x.min()) / bin_width)
+    return bins
+
+
+def plot_histogram(x: np.ndarray, **kwargs) -> None:
+    _, plt = import_mpl_plt()
+    plt.hist(x, bins=num_bins(x), **kwargs)
+    plt.xlabel('Intensity')
+    density = kwargs.pop('density', False)
+    if density:
+        plt.ylabel('Density')
+    else:
+        plt.ylabel('Frequency')
+    plt.show()
+
+
 def color_labels(arrays, cmap_dict):
     results = []
     for array in arrays:


### PR DESCRIPTION
**Description**
Hi @fepegar,

These are a few code snippets I find myself running very often and thought maybe it would be good to integrate into the code base. The `Image.plot()` (and now `Image.show()`) are helpful for visually inspecting the data and ensuring spatial transforms are doing what we think, and so I propose the new `ScalarImage.hist()` method for inspecting intensity histograms to get a feel for the data and to ensure intensity transforms are doing what is expected.

I also added two simple functions for inspecting the label maps by counting non-zeroes (foreground vs. background) and for counting the labels therein (returned as dictionary of label counts).

If you aren't interested in these, no worries at all! I just use them often for debugging that I thought they may have a wider audience.

**Checklist**

- [X] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [X] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [X] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [X] This pull request is ready to be reviewed
- [X] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
