### PR TITLE
Add kwarg to not check spatial consistency

### DIFF
--- a/tests/transforms/augmentation/test_random_affine.py
+++ b/tests/transforms/augmentation/test_random_affine.py
@@ -167,3 +167,11 @@ class TestRandomAffine(TorchioTestCase):
         )
         transformed = apply_affine(tensor)
         self.assertTensorAlmostEqual(transformed, expected)
+
+    def test_different_spaces(self):
+        t1 = self.sample_subject.t1
+        label = tio.Resample(2)(self.sample_subject.label)
+        new_subject = tio.Subject(t1=t1, label=label)
+        with self.assertRaises(RuntimeError):
+            tio.RandomAffine()(new_subject)
+        tio.RandomAffine(check_shape=False)(new_subject)


### PR DESCRIPTION
Related to #734.

**Description**
The new kwarg allows to avoid checks for spatial consistency across images within a subject. This is useful when we are certain that the images are in the same physical space but different voxel space or different orientation. See the @Spenhouet's issue for more information:
- #734

The recommended usage in this case is

```python
RandomAffine(center='origin', check_shape=False)
```

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
