### PR TITLE
Add logic to invert OneHot transform

### DIFF
--- a/tests/transforms/preprocessing/test_one_hot.py
+++ b/tests/transforms/preprocessing/test_one_hot.py
@@ -14,3 +14,12 @@ class TestOneHot(TorchioTestCase):
         label_map = tio.LabelMap(tensor=torch.rand(2, 3, 3, 3) > 1)
         with self.assertRaises(RuntimeError):
             tio.OneHot()(label_map)
+
+    def test_inverse(self):
+        one_hot = tio.OneHot()
+        subject_one_hot = one_hot(self.sample_subject)
+        subject_back = subject_one_hot.apply_inverse_transform()
+        self.assertTensorEqual(
+            self.sample_subject.label.data,
+            subject_back.label.data,
+        )

--- a/torchio/transforms/preprocessing/label/one_hot.py
+++ b/torchio/transforms/preprocessing/label/one_hot.py
@@ -1,5 +1,6 @@
 import torch.nn.functional as F  # noqa: N812
 
+from ....data.image import Image
 from .label_transform import LabelTransform
 
 
@@ -15,17 +16,29 @@ class OneHot(LabelTransform):
         super().__init__(**kwargs)
         self.num_classes = num_classes
         self.args_names = ('num_classes',)
+        self.invert_transform = False
 
     def apply_transform(self, subject):
         for image in self.get_images(subject):
-            if image.num_channels > 1:
-                message = (
-                    'The number of input channels must be 1,'
-                    f' but it is {image.num_channels}'
-                )
-                raise RuntimeError(message)
-            data = image.data[0]
-            num_classes = -1 if self.num_classes is None else self.num_classes
-            one_hot = F.one_hot(data.long(), num_classes=num_classes)
-            image.set_data(one_hot.permute(3, 0, 1, 2).type(data.type()))
+            if self.invert_transform:
+                self.argmax(image)
+            else:
+                self.one_hot(image)
         return subject
+
+    @staticmethod
+    def argmax(image: Image) -> None:
+        data = image.data.argmax(dim=0, keepdim=True)
+        image.set_data(data)
+
+    def one_hot(self, image: Image) -> None:
+        if image.num_channels > 1:
+            message = (
+                'The number of input channels must be 1,'
+                f' but it is {image.num_channels}'
+            )
+            raise RuntimeError(message)
+        data = image.data[0]
+        num_classes = -1 if self.num_classes is None else self.num_classes
+        one_hot = F.one_hot(data.long(), num_classes=num_classes)
+        image.set_data(one_hot.permute(3, 0, 1, 2).type(data.type()))


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Related to
- #743


**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
