### PR TITLE
Fix wrong class when creating subjects from batch

### DIFF
--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -251,7 +251,7 @@ def get_subjects_from_batch(batch: Dict) -> List:
             data = image_dict[constants.DATA][i]
             affine = image_dict[constants.AFFINE][i]
             path = Path(image_dict[constants.PATH][i])
-            is_label = image_dict[constants.TYPE] == constants.LABEL
+            is_label = image_dict[constants.TYPE][i] == constants.LABEL
             klass = LabelMap if is_label else ScalarImage
             image = klass(tensor=data, affine=affine, filename=path.name)
             subject_dict[image_name] = image


### PR DESCRIPTION
Reported by @Bigsealion in #743.

**Description**
When a batch dictionary is checked to create a list of instances of subjects from it, the image type retrieval was not happening correctly.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
