### PR TITLE
Fix CropOrPad incorrectly storing bounds

### DIFF
--- a/torchio/datasets/bite.py
+++ b/torchio/datasets/bite.py
@@ -33,7 +33,6 @@ class BITE(SubjectsDataset, abc.ABC):
 
 
 class BITE3(BITE):
-    dirname = 'group3'
     """Pre- and post-resection MR images in BITE.
 
     *The goal of BITE is to share in vivo medical images of patients wtith
@@ -51,6 +50,8 @@ class BITE3(BITE):
             :class:`~torchio.transforms.transform.Transform`.
         download: If set to ``True``, will download the data into :attr:`root`.
     """  # noqa: E501
+    dirname = 'group3'
+
     def _download(self, root: Path):
         if (root / self.dirname).is_dir():
             return

--- a/torchio/utils.py
+++ b/torchio/utils.py
@@ -337,3 +337,21 @@ def guess_external_viewer() -> Optional[Path]:
         slicer_path = shutil.which('Slicer')
         if slicer_path is not None:
             return Path(slicer_path)
+
+
+def parse_spatial_shape(shape):
+    result = to_tuple(shape, length=3)
+    for n in result:
+        if n < 1 or n % 1:
+            message = (
+                'All elements in a spatial shape must be positive integers,'
+                f' but the following shape was passed: {shape}'
+            )
+            raise ValueError(message)
+    if len(result) != 3:
+        message = (
+            'Spatial shapes must have 3 elements, but the following shape'
+            f' was passed: {shape}'
+        )
+        raise ValueError(message)
+    return result


### PR DESCRIPTION
Fixes #757.

**Description**
The current implementation of `CropOrPad` incorrectly stores some data in `self`, causing the bug described in:
- #757

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [ ] Non-breaking change (would not break existing functionality)
- [x] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
