### PR TITLE
Fix affine getter for multipath images

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,7 @@
+coverage:
+  status:
+    project: false
+
 ignore:
   - "setup.py"
   - "torchio/external/due.py"

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -97,13 +97,16 @@ class TestImage(TorchioTestCase):
         with self.assertRaises(FileNotFoundError):
             tio.ScalarImage(path=['nopath', 'error'])
 
-    def test_with_a_list_of_paths(self):
+    def test_with_sequences_of_paths(self):
         shape = (5, 5, 5)
         path1 = self.get_image_path('path1', shape=shape)
         path2 = self.get_image_path('path2', shape=shape)
-        image = tio.ScalarImage(path=[path1, path2])
-        self.assertEqual(image.shape, (2, 5, 5, 5))
-        self.assertEqual(image[tio.STEM], ['path1', 'path2'])
+        paths_tuple = path1, path2
+        paths_list = list(paths_tuple)
+        for sequence in (paths_tuple, paths_list):
+            image = tio.ScalarImage(path=sequence)
+            self.assertEqual(image.shape, (2, 5, 5, 5))
+            self.assertEqual(image[tio.STEM], ['path1', 'path2'])
 
     def test_with_a_list_of_images_with_different_shapes(self):
         path1 = self.get_image_path('path1', shape=(5, 5, 5))
@@ -227,3 +230,11 @@ class TestImage(TorchioTestCase):
         assert tuple(counts) == (0, 1)
         assert 0 <= counts[0] <= max_n
         assert 0 <= counts[1] <= max_n
+
+    def test_affine_multipath(self):
+        # https://github.com/fepegar/torchio/issues/762
+        path1 = self.get_image_path('multi1')
+        path2 = self.get_image_path('multi2')
+        paths = path1, path2
+        image = tio.ScalarImage(paths)
+        self.assertTensorEqual(image.affine, np.eye(4))

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -1,7 +1,6 @@
 import warnings
 from pathlib import Path
 from collections import Counter
-from collections.abc import Iterable
 from typing import Any, Dict, Tuple, Optional, Union, Sequence, List, Callable
 
 import torch
@@ -230,8 +229,7 @@ class Image(dict):
         """Affine matrix to transform voxel indices into world coordinates."""
         # If path is a dir (probably DICOM), just load the data
         # Same if it's a list of paths (used to create a 4D image)
-        is_dir = isinstance(self.path, Path) and self.path.is_dir()
-        if self._loaded or is_dir:
+        if self._loaded or self._is_dir() or self._is_multipath():
             affine = self[AFFINE]
         else:
             affine = read_affine(self.path)
@@ -423,7 +421,7 @@ class Image(dict):
             ) -> Optional[Union[Path, List[Path]]]:
         if path is None:
             return None
-        if isinstance(path, Iterable) and not isinstance(path, str):
+        elif self._is_paths_sequence(path):
             return [self._parse_single_path(p) for p in path]
         else:
             return self._parse_single_path(path)
@@ -474,6 +472,27 @@ class Image(dict):
             raise ValueError(f'Affine shape must be (4, 4), not {bad_shape}')
         return affine.astype(np.float64)
 
+    @staticmethod
+    def _is_paths_sequence(path):
+        is_string = isinstance(path, str)
+        try:
+            is_iterable = iter(path)
+        except TypeError:
+            is_iterable = False
+        return is_iterable and not is_string
+
+    def _is_multipath(self):
+        return self._is_paths_sequence(self.path)
+
+    def _is_dir(self):
+        is_sequence = self._is_multipath()
+        if is_sequence:
+            return False
+        elif self.path is None:
+            return False
+        else:
+            return self.path.is_dir()
+
     def load(self) -> None:
         r"""Load the image from disk.
 
@@ -484,7 +503,7 @@ class Image(dict):
         """
         if self._loaded:
             return
-        paths = self.path if isinstance(self.path, list) else [self.path]
+        paths = self.path if self._is_multipath() else [self.path]
         tensor, affine = self.read_and_check(paths[0])
         tensors = [tensor]
         for path in paths[1:]:


### PR DESCRIPTION
Fixes #762.

**Description**
An error was being raised when trying to get the affine of multipath images, as the list of paths was being passed to the SimpleITK reader. Now, the images are loaded before returning the affine if the image is multipath.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)

@dmus 