### PR TITLE
Disabling plotting tests on Windows

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -139,6 +139,7 @@ class TestImage(TorchioTestCase):
         self.assertEqual(image.height, image.shape[height_idx])
         self.assertEqual(image.width, image.shape[width_idx])
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason='Unstable on Windows')
     def test_plot(self):
         image = self.sample_subject.t1
         image.plot(show=False, output_path=self.dir / 'image.png')

--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -1,6 +1,9 @@
+import sys
 import copy
 import tempfile
+
 import torch
+import pytest
 import numpy as np
 import torchio as tio
 from ..utils import TorchioTestCase
@@ -47,6 +50,7 @@ class TestSubject(TorchioTestCase):
         with self.assertRaises(RuntimeError):
             subject.spatial_shape
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason='Unstable on Windows')
     def test_plot(self):
         self.sample_subject.plot(
             show=False,
@@ -57,6 +61,7 @@ class TestSubject(TorchioTestCase):
             },
         )
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason='Unstable on Windows')
     def test_plot_one_image(self):
         path = self.get_image_path('t1_plot')
         subject = tio.Subject(t1=tio.ScalarImage(path))


### PR DESCRIPTION
As they keep falling (apparently) randomly. Example: https://github.com/fepegar/torchio/runs/4404019863?check_suite_focus=true


<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->