### PR TITLE
Fix `Blur` using only the first standard deviation

### DIFF
--- a/torchio/transforms/augmentation/intensity/random_blur.py
+++ b/torchio/transforms/augmentation/intensity/random_blur.py
@@ -5,7 +5,6 @@ import torch
 import numpy as np
 import scipy.ndimage as ndi
 
-from ....utils import to_tuple
 from ....typing import TypeData, TypeTripletFloat, TypeSextetFloat
 from ....data.subject import Subject
 from ... import IntensityTransform
@@ -72,15 +71,15 @@ class Blur(IntensityTransform):
         self.args_names = ('std',)
 
     def apply_transform(self, subject: Subject) -> Subject:
-        std = self.std
+        stds = self.std
         for name, image in self.get_images_dict(subject).items():
             if self.arguments_are_dict():
-                std = self.std[name]
-            stds = to_tuple(std, length=len(image.data))
+                stds = self.std[name]
+            stds_channels = np.tile(stds, (image.num_channels, 1))
             transformed_tensors = []
-            for std, tensor in zip(stds, image.data):
+            for std, channel in zip(stds_channels, image.data):
                 transformed_tensor = blur(
-                    tensor,
+                    channel,
                     image.spacing,
                     std,
                 )

--- a/torchio/transforms/augmentation/intensity/random_blur.py
+++ b/torchio/transforms/augmentation/intensity/random_blur.py
@@ -39,9 +39,9 @@ class RandomBlur(RandomTransform, IntensityTransform):
 
     def apply_transform(self, subject: Subject) -> Subject:
         arguments = defaultdict(dict)
-        for name, image in self.get_images_dict(subject).items():
-            stds = [self.get_params(self.std_ranges) for _ in image.data]
-            arguments['std'][name] = stds
+        for name in self.get_images_dict(subject):
+            std = self.get_params(self.std_ranges)
+            arguments['std'][name] = std
         transform = Blur(**self.add_include_exclude(arguments))
         transformed = transform(subject)
         return transformed


### PR DESCRIPTION
Fixes #769.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
