### PR TITLE
Add support to specify the interpolation type for label images

### DIFF
--- a/docs/source/transforms/transforms.rst
+++ b/docs/source/transforms/transforms.rst
@@ -174,10 +174,9 @@ fast, but produces relatively poor results.
 ``'linear'``, default in TorchIO, is usually a good compromise between image
 quality and speed to be used for data augmentation during training.
 
-Instances of :class:`~torchio.data.image.LabelMap` are always resampled using
-nearest neighbor interpolation, independently of the interpolation type
-specified at transform instantiation, which will be used for instances of
-:class:`~torchio.data.image.ScalarImage`.
+When instantiating transforms it is possible to specify independently the interpolation for labels and images.
+``'label_interpolation'`` will be used for instances of :class:`~torchio.data.image.LabelMap` and
+``'image_interpolation'`` will be used for instances of :class:`~torchio.data.image.ScalarImage`.
 
 Methods such as ``'bspline'`` or ``'lanczos'`` generate
 high-quality results, but are generally slower. They can be used to obtain

--- a/docs/source/transforms/transforms.rst
+++ b/docs/source/transforms/transforms.rst
@@ -168,19 +168,22 @@ need to interpolate intensity values during resampling.
 The available interpolation strategies can be inferred from the elements of
 :class:`~torchio.transforms.interpolation.Interpolation`.
 
-``'nearest'`` can be used for quick experimentation as it is very
-fast, but produces relatively poor results.
-
-``'linear'``, default in TorchIO, is usually a good compromise between image
-quality and speed to be used for data augmentation during training.
-
-When instantiating transforms it is possible to specify independently the interpolation for labels and images.
-``'label_interpolation'`` will be used for instances of :class:`~torchio.data.image.LabelMap` and
-``'image_interpolation'`` will be used for instances of :class:`~torchio.data.image.ScalarImage`.
+``'linear'`` interpolation, the default in TorchIO for scalar images,
+is usually a good compromise between image quality and speed.
+It is therefore a good choice for data augmentation during training.
 
 Methods such as ``'bspline'`` or ``'lanczos'`` generate
 high-quality results, but are generally slower. They can be used to obtain
 optimal resampling results during offline data preprocessing.
+
+``'nearest'`` can be used for quick experimentation as it is very
+fast, but produces relatively poor results for scalar images.
+It is the default interpolation type for label maps, as categorical values for
+the different labels need to preserved after interpolation.
+
+When instantiating transforms, it is possible to specify independently the
+interpolation type for label maps and scalar images, as shown in the
+documentation for, e.g., :class:`~torchio.transforms.Resample`.
 
 Visit the
 `SimpleITK docs <https://simpleitk.org/doxygen/latest/html/namespaceitk_1_1simple.html#a7cb1ef8bd02c669c02ea2f9f5aa374e5>`_
@@ -194,8 +197,6 @@ for some further general explanations of digital image interpolation.
     :show-inheritance:
     :members:
     :undoc-members:
-
-
 
 
 Transforms API

--- a/torchio/transforms/augmentation/spatial/random_affine.py
+++ b/torchio/transforms/augmentation/spatial/random_affine.py
@@ -75,6 +75,7 @@ class RandomAffine(RandomTransform, SpatialTransform):
             `Otsu threshold <https://ieeexplore.ieee.org/document/4310076>`_.
             If it is a number, that value will be used.
         image_interpolation: See :ref:`Interpolation`.
+        label_interpolation: See :ref:`Interpolation`.
         check_shape: If ``True`` an error will be raised if the images are in
             different physical spaces. If ``False``, :attr:`center` should
             probably not be ``'image'`` but ``'center'``.
@@ -111,6 +112,7 @@ class RandomAffine(RandomTransform, SpatialTransform):
             center: str = 'image',
             default_pad_value: Union[str, float] = 'minimum',
             image_interpolation: str = 'linear',
+            label_interpolation: str = 'nearest',
             check_shape: bool = True,
             **kwargs
             ):
@@ -130,6 +132,8 @@ class RandomAffine(RandomTransform, SpatialTransform):
         self.default_pad_value = _parse_default_value(default_pad_value)
         self.image_interpolation = self.parse_interpolation(
             image_interpolation)
+        self.label_interpolation = self.parse_interpolation(
+            label_interpolation)
         self.check_shape = check_shape
 
     def get_params(
@@ -160,6 +164,7 @@ class RandomAffine(RandomTransform, SpatialTransform):
             'center': self.center,
             'default_pad_value': self.default_pad_value,
             'image_interpolation': self.image_interpolation,
+            'label_interpolation': self.label_interpolation,
             'check_shape': self.check_shape,
         }
         transform = Affine(**self.add_include_exclude(arguments))
@@ -189,6 +194,7 @@ class Affine(SpatialTransform):
             `Otsu threshold <https://ieeexplore.ieee.org/document/4310076>`_.
             If it is a number, that value will be used.
         image_interpolation: See :ref:`Interpolation`.
+        label_interpolation: See :ref:`Interpolation`.
         check_shape: If ``True`` an error will be raised if the images are in
             different physical spaces. If ``False``, :attr:`center` should
             probably not be ``'image'`` but ``'center'``.
@@ -203,6 +209,7 @@ class Affine(SpatialTransform):
             center: str = 'image',
             default_pad_value: Union[str, float] = 'minimum',
             image_interpolation: str = 'linear',
+            label_interpolation: str = 'nearest',
             check_shape: bool = True,
             **kwargs
             ):
@@ -237,6 +244,8 @@ class Affine(SpatialTransform):
         self.default_pad_value = _parse_default_value(default_pad_value)
         self.image_interpolation = self.parse_interpolation(
             image_interpolation)
+        self.label_interpolation = self.parse_interpolation(
+            label_interpolation)
         self.invert_transform = False
         self.check_shape = check_shape
         self.args_names = (
@@ -246,6 +255,7 @@ class Affine(SpatialTransform):
             'center',
             'default_pad_value',
             'image_interpolation',
+            'label_interpolation',
             'check_shape',
         )
 
@@ -343,7 +353,7 @@ class Affine(SpatialTransform):
                     force_3d=True,
                 )
                 if image[TYPE] != INTENSITY:
-                    interpolation = 'nearest'
+                    interpolation = self.label_interpolation
                     default_value = 0
                 else:
                     interpolation = self.image_interpolation

--- a/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
+++ b/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
@@ -60,6 +60,7 @@ class RandomElasticDeformation(RandomTransform, SpatialTransform):
             The value of the dense displacement at each voxel is always
             interpolated with cubic B-splines from the values at the control
             points of the coarse grid.
+        label_interpolation: See :ref:`Interpolation`.
         **kwargs: See :class:`~torchio.transforms.Transform` for additional
             keyword arguments.
 
@@ -122,6 +123,7 @@ class RandomElasticDeformation(RandomTransform, SpatialTransform):
             max_displacement: Union[float, Tuple[float, float, float]] = 7.5,
             locked_borders: int = 2,
             image_interpolation: str = 'linear',
+            label_interpolation: str = 'nearest',
             **kwargs
             ):
         super().__init__(**kwargs)
@@ -142,7 +144,9 @@ class RandomElasticDeformation(RandomTransform, SpatialTransform):
             raise ValueError(message)
         self.image_interpolation = self.parse_interpolation(
             image_interpolation)
-
+        self.label_interpolation = self.parse_interpolation(
+            label_interpolation)
+            
     @staticmethod
     def get_params(
             num_control_points: TypeTripletInt,
@@ -179,6 +183,7 @@ class RandomElasticDeformation(RandomTransform, SpatialTransform):
             'control_points': control_points,
             'max_displacement': self.max_displacement,
             'image_interpolation': self.image_interpolation,
+            'label_interpolation': self.label_interpolation,
         }
 
         transform = ElasticDeformation(**self.add_include_exclude(arguments))
@@ -193,6 +198,7 @@ class ElasticDeformation(SpatialTransform):
         control_points:
         max_displacement:
         image_interpolation: See :ref:`Interpolation`.
+        label_interpolation: See :ref:`Interpolation`.
         **kwargs: See :class:`~torchio.transforms.Transform` for additional
             keyword arguments.
     """
@@ -202,6 +208,7 @@ class ElasticDeformation(SpatialTransform):
             control_points: np.ndarray,
             max_displacement: TypeTripletFloat,
             image_interpolation: str = 'linear',
+            label_interpolation: str = 'nearest',
             **kwargs
             ):
         super().__init__(**kwargs)
@@ -209,10 +216,13 @@ class ElasticDeformation(SpatialTransform):
         self.max_displacement = max_displacement
         self.image_interpolation = self.parse_interpolation(
             image_interpolation)
+        self.label_interpolation = self.parse_interpolation(
+            label_interpolation)
         self.invert_transform = False
         self.args_names = (
             'control_points',
             'image_interpolation',
+            'label_interpolation',
             'max_displacement',
         )
 
@@ -259,7 +269,7 @@ class ElasticDeformation(SpatialTransform):
         subject.check_consistent_spatial_shape()
         for image in self.get_images(subject):
             if not isinstance(image, ScalarImage):
-                interpolation = 'nearest'
+                interpolation = self.label_interpolation
             else:
                 interpolation = self.image_interpolation
             transformed = self.apply_bspline_transform(

--- a/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
+++ b/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
@@ -198,7 +198,7 @@ class ElasticDeformation(SpatialTransform):
         control_points:
         max_displacement:
         image_interpolation: See :ref:`Interpolation`.
-        label_interpolation: See :ref: Interpolation`.
+        label_interpolation: See :ref:`Interpolation`.
         **kwargs: See :class:`~torchio.transforms.Transform` for additional
             keyword arguments.
     """

--- a/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
+++ b/torchio/transforms/augmentation/spatial/random_elastic_deformation.py
@@ -146,7 +146,7 @@ class RandomElasticDeformation(RandomTransform, SpatialTransform):
             image_interpolation)
         self.label_interpolation = self.parse_interpolation(
             label_interpolation)
-            
+
     @staticmethod
     def get_params(
             num_control_points: TypeTripletInt,
@@ -198,7 +198,7 @@ class ElasticDeformation(SpatialTransform):
         control_points:
         max_displacement:
         image_interpolation: See :ref:`Interpolation`.
-        label_interpolation: See :ref:`Interpolation`.
+        label_interpolation: See :ref: Interpolation`.
         **kwargs: See :class:`~torchio.transforms.Transform` for additional
             keyword arguments.
     """

--- a/torchio/transforms/preprocessing/spatial/resample.py
+++ b/torchio/transforms/preprocessing/spatial/resample.py
@@ -42,6 +42,7 @@ class Resample(SpatialTransform):
             resampling. If ``None``, the image is resampled with an identity
             transform. See usage in the example below.
         image_interpolation: See :ref:`Interpolation`.
+        label_interpolation: See :ref:`Interpolation`.
         scalars_only: Apply only to instances of :class:`~torchio.ScalarImage`.
             Used internally by :class:`~torchio.transforms.RandomAnisotropy`.
         **kwargs: See :class:`~torchio.transforms.Transform` for additional
@@ -75,6 +76,7 @@ class Resample(SpatialTransform):
             self,
             target: Union[TypeSpacing, str, Path, Image, None] = 1,
             image_interpolation: str = 'linear',
+            label_interpolation: str = 'nearest',
             pre_affine_name: Optional[str] = None,
             scalars_only: bool = False,
             **kwargs
@@ -83,11 +85,14 @@ class Resample(SpatialTransform):
         self.target = target
         self.image_interpolation = self.parse_interpolation(
             image_interpolation)
+        self.label_interpolation = self.parse_interpolation(
+            label_interpolation)
         self.pre_affine_name = pre_affine_name
         self.scalars_only = scalars_only
         self.args_names = (
             'target',
             'image_interpolation',
+            'label_interpolation',
             'pre_affine_name',
             'scalars_only',
         )
@@ -163,7 +168,7 @@ class Resample(SpatialTransform):
             if not isinstance(image, ScalarImage):
                 if self.scalars_only:
                     continue
-                interpolation = 'nearest'
+                interpolation = self.label_interpolation
             else:
                 interpolation = self.image_interpolation
             interpolator = self.get_sitk_interpolator(interpolation)

--- a/torchio/transforms/preprocessing/spatial/resize.py
+++ b/torchio/transforms/preprocessing/spatial/resize.py
@@ -26,20 +26,25 @@ class Resize(SpatialTransform):
             provided, then :math:`W = H = D = N`. The size of dimensions set to
             -1 will be kept.
         image_interpolation: See :ref:`Interpolation`.
+        label_interpolation: See :ref:`Interpolation`.
     """
     def __init__(
             self,
             target_shape: TypeSpatialShape,
             image_interpolation: str = 'linear',
+            label_interpolation: str = 'nearest',
             **kwargs
             ):
         super().__init__(**kwargs)
         self.target_shape = np.asarray(to_tuple(target_shape, length=3))
         self.image_interpolation = self.parse_interpolation(
             image_interpolation)
+        self.label_interpolation = self.parse_interpolation(
+            label_interpolation)
         self.args_names = (
             'target_shape',
             'image_interpolation',
+            'label_interpolation',
         )
 
     def apply_transform(self, subject: Subject) -> Subject:
@@ -52,6 +57,7 @@ class Resize(SpatialTransform):
         resample = Resample(
             spacing_out,
             image_interpolation=self.image_interpolation,
+            label_interpolation=self.label_interpolation,
         )
         resampled = resample(subject)
         # Sometimes, the output shape is one voxel too large


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #782.

**Description**
Adds label_interpolation parameter in spatial augmentations and transforms

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
