### PR TITLE
add py.typed marker file for type checking in mypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Typing :: Typed',
     ],
     description=(
         'Tools for loading, augmenting and writing 3D medical images'
@@ -58,6 +59,7 @@ setup(
     include_package_data=True,
     keywords='torchio',
     name='torchio',
+    package_data={'torchio': ['py.typed']},
     packages=find_packages(include=['torchio', 'torchio.*']),
     setup_requires=[],
     test_suite='tests',


### PR DESCRIPTION
Fixes #807.

**Description**

This PR adds a py.typed marker file so that end users can make use of type annotations in torchio in mypy.

This PR doesn't fix the current state of the type annotations which need to be reworked to work properly with mypy.

I tested this implementation in another project using torchio, and mypy recognizes the py.typed marker file.

**Checklist**

- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes (**Not relevant**)
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated  (**Not relevant**)
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder  (**Not relevant**)
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)  (**Not relevant**)
