### PR TITLE
Fix overlapping in patches aggregator

### DIFF
--- a/tests/data/inference/test_aggregator.py
+++ b/tests/data/inference/test_aggregator.py
@@ -71,3 +71,35 @@ class TestAggregator(TorchioTestCase):
         aggregator = self.run_sampler_aggregator()
         with self.assertWarns(RuntimeWarning):
             aggregator.get_output_tensor()
+
+    def run_patch_crop_issue(self, *, padding_mode):
+        # https://github.com/fepegar/torchio/issues/813
+        pao, pas, ims, bb1, bb2 = 4, 102, 320, 100, 120
+
+        patch_overlap = pao, 0, 0
+        patch_size = pas, 1, 1
+        img = torch.zeros((1, ims, 1, 1))
+        bbox = [bb1, bb2]
+
+        img[:, bbox[0]:bbox[1]] = 1
+        image = tio.LabelMap(tensor=img)
+        subject = tio.Subject(image=image)
+        grid_sampler = tio.inference.GridSampler(
+            subject,
+            patch_size,
+            patch_overlap,
+        )
+        patch_loader = torch.utils.data.DataLoader(grid_sampler)
+        aggregator = tio.inference.GridAggregator(grid_sampler)
+        for patches_batch in patch_loader:
+            input_tensor = patches_batch['image'][tio.DATA]
+            locations = patches_batch[tio.LOCATION]
+            aggregator.add_batch(input_tensor, locations)
+        output_tensor = aggregator.get_output_tensor()
+        self.assertTensorEqual(image.tensor, output_tensor)
+
+    def test_patch_crop_issue_no_padding(self):
+        self.run_patch_crop_issue(padding_mode=None)
+
+    def test_patch_crop_issue_padding(self):
+        self.run_patch_crop_issue(padding_mode='constant')

--- a/torchio/data/inference/aggregator.py
+++ b/torchio/data/inference/aggregator.py
@@ -4,7 +4,6 @@ from typing import Tuple
 import torch
 import numpy as np
 
-from ...typing import TypeData
 from ...constants import CHANNELS_DIMENSION
 from ..sampler import GridSampler
 
@@ -35,12 +34,12 @@ class GridAggregator:
         self.spatial_shape = subject.spatial_shape
         self._output_tensor = None
         self.patch_overlap = sampler.patch_overlap
-        self.parse_overlap_mode(overlap_mode)
+        self._parse_overlap_mode(overlap_mode)
         self.overlap_mode = overlap_mode
         self._avgmask_tensor = None
 
     @staticmethod
-    def parse_overlap_mode(overlap_mode):
+    def _parse_overlap_mode(overlap_mode):
         if overlap_mode not in ('crop', 'average'):
             message = (
                 'Overlap mode must be "crop" or "average" but '
@@ -48,46 +47,38 @@ class GridAggregator:
             )
             raise ValueError(message)
 
-    def crop_batch(
+    def _crop_patch(
             self,
-            batch: torch.Tensor,
-            locations: np.ndarray,
+            patch: torch.Tensor,
+            location: np.ndarray,
             overlap: np.ndarray,
-            ) -> Tuple[TypeData, np.ndarray]:
-        border = np.array(overlap) // 2  # overlap is even in grid sampler
-        crop_locations = locations.astype(int).copy()
-        indices_ini, indices_fin = crop_locations[:, :3], crop_locations[:, 3:]
-        num_locations = len(crop_locations)
+            ) -> Tuple[torch.Tensor, np.ndarray]:
+        half_overlap = overlap // 2  # overlap is always even in grid sampler
+        index_ini, index_fin = location[:3], location[3:]
 
-        border_ini = np.tile(border, (num_locations, 1))
-        border_fin = border_ini.copy()
-        # Do not crop patches at the border of the volume
-        # Unless we're padding the volume in the grid sampler. In that case,
-        # it doesn't matter if we don't crop patches at the border, because the
-        # output volume will be cropped
-        if not self.volume_padded:
-            mask_border_ini = indices_ini == 0
-            border_ini[mask_border_ini] = 0
-            for axis, size in enumerate(self.spatial_shape):
-                mask_border_fin = indices_fin[:, axis] == size
-                border_fin[mask_border_fin, axis] = 0
+        # If the patch is not at the border, we crop half the overlap
+        crop_ini = half_overlap.copy()
+        crop_fin = half_overlap.copy()
 
-        indices_ini += border_ini
-        indices_fin -= border_fin
+        # If the volume has been padded, we don't need to worry about cropping
+        if self.volume_padded:
+            pass
+        else:
+            crop_ini *= index_ini > 0
+            crop_fin *= index_fin != self.spatial_shape
 
-        crop_shapes = indices_fin - indices_ini
-        patch_shape = batch.shape[2:]  # ignore batch and channels dim
-        cropped_patches = []
-        for patch, crop_shape in zip(batch, crop_shapes):
-            diff = patch_shape - crop_shape
-            left = (diff / 2).astype(int)
-            i_ini, j_ini, k_ini = left
-            i_fin, j_fin, k_fin = left + crop_shape
-            cropped_patch = patch[:, i_ini:i_fin, j_ini:j_fin, k_ini:k_fin]
-            cropped_patches.append(cropped_patch)
-        return cropped_patches, crop_locations
+        # Update the location of the patch in the volume
+        new_index_ini = index_ini + crop_ini
+        new_index_fin = index_fin - crop_fin
+        new_location = np.hstack((new_index_ini, new_index_fin))
 
-    def initialize_output_tensor(self, batch: torch.Tensor) -> None:
+        patch_size = patch.shape[-3:]
+        i_ini, j_ini, k_ini = crop_ini
+        i_fin, j_fin, k_fin = patch_size - crop_fin
+        cropped_patch = patch[:, i_ini:i_fin, j_ini:j_fin, k_ini:k_fin]
+        return cropped_patch, new_location
+
+    def _initialize_output_tensor(self, batch: torch.Tensor) -> None:
         if self._output_tensor is not None:
             return
         num_channels = batch.shape[CHANNELS_DIMENSION]
@@ -97,7 +88,7 @@ class GridAggregator:
             dtype=batch.dtype,
         )
 
-    def initialize_avgmask_tensor(self, batch: torch.Tensor) -> None:
+    def _initialize_avgmask_tensor(self, batch: torch.Tensor) -> None:
         if self._avgmask_tensor is not None:
             return
         num_channels = batch.shape[CHANNELS_DIMENSION]
@@ -123,22 +114,22 @@ class GridAggregator:
         """
         batch = batch_tensor.cpu()
         locations = locations.cpu().numpy()
-        self.initialize_output_tensor(batch)
+        self._initialize_output_tensor(batch)
         if self.overlap_mode == 'crop':
-            cropped_patches, crop_locations = self.crop_batch(
-                batch,
-                locations,
-                self.patch_overlap,
-            )
-            for patch, crop_location in zip(cropped_patches, crop_locations):
-                i_ini, j_ini, k_ini, i_fin, j_fin, k_fin = crop_location
+            for patch, location in zip(batch, locations):
+                cropped_patch, new_location = self._crop_patch(
+                    patch,
+                    location,
+                    self.patch_overlap,
+                )
+                i_ini, j_ini, k_ini, i_fin, j_fin, k_fin = new_location
                 self._output_tensor[
                     :,
                     i_ini:i_fin,
                     j_ini:j_fin,
-                    k_ini:k_fin] = patch
+                    k_ini:k_fin] = cropped_patch
         elif self.overlap_mode == 'average':
-            self.initialize_avgmask_tensor(batch)
+            self._initialize_avgmask_tensor(batch)
             for patch, location in zip(batch, locations):
                 i_ini, j_ini, k_ini, i_fin, j_fin, k_fin = location
                 self._output_tensor[


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #813.

**Description**
This PR fixes a bug in the aggregator. When certain conditions were met, overlapping patches were over-cropped, causing spatial shifting between the input and output volumes during inference with a grid sampler and an aggregator.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [ ] Non-breaking change (would not break existing functionality)
- [x] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
