### PR TITLE
Add support for torch >= 1.11

### DIFF
--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -109,5 +109,5 @@ class TestSubject(TorchioTestCase):
             tio.Subject(0)
 
     def test_no_images(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             tio.Subject(a=0)

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -424,8 +424,9 @@ class Image(dict):
             ) -> Optional[Union[Path, List[Path]]]:
         if path is None:
             return None
-        elif type(path) is dict:
-            raise TypeError('The variable path cannot be a dictionary')
+        elif isinstance(path, dict):
+            # https://github.com/fepegar/torchio/pull/838
+            raise TypeError('The path argument cannot be a dictionary')
         elif self._is_paths_sequence(path):
             return [self._parse_single_path(p) for p in path]
         else:

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -424,6 +424,8 @@ class Image(dict):
             ) -> Optional[Union[Path, List[Path]]]:
         if path is None:
             return None
+        elif type(path) is dict:
+            raise TypeError('The variable path cannot be a dictionary')
         elif self._is_paths_sequence(path):
             return [self._parse_single_path(p) for p in path]
         else:

--- a/torchio/data/subject.py
+++ b/torchio/data/subject.py
@@ -82,7 +82,7 @@ class Subject(dict):
     def _parse_images(images: List[Tuple[str, Image]]) -> None:
         # Check that it's not empty
         if not images:
-            raise ValueError('A subject without images cannot be created')
+            raise TypeError('A subject without images cannot be created')
 
     @property
     def shape(self):


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #811 

**Description**
What is happening:
The last called torch function default_collate() has been changed (from torch>=1.11.0) in order to support a bigger variety of user-cases. By the way it has been modified, it calls the init() of the input batch-type (in our case, we are talking about Subject) and, if it raises a TypeError (standard exception for wrong type of arguments as input), then the pytorch code could continue  - basically running the same code that we have been running with previous versions of pytorch. The latter branch of the code, does not call init(), which I believe it is indeed what we want, since the Subject class goes out of scope after a batch has been prepared. 
Right now, there are two things that are not ideal:
- class Image does not recognize on the spot that it has been called with the wrong type of data (path as dictionary)
- class Subject raise a ValueError instead of TypeError, when it is called with no supplied Images

With the proposed fix, the kind of raised exception changes, as well as an additional check has been added in Image. 


**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [ ] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
