### PR TITLE
Fix the wrong mapping in sequential labels transform

### DIFF
--- a/torchio/transforms/preprocessing/label/sequential_labels.py
+++ b/torchio/transforms/preprocessing/label/sequential_labels.py
@@ -8,9 +8,9 @@ from .label_transform import LabelTransform
 class SequentialLabels(LabelTransform):
     r"""Remap the integer IDs of labels in a LabelMap to be sequential.
 
-    For example, if a label map has 6 labels with IDs (3, 5, 9, 15, 16, 23),
+    For example, if a label map has 7 labels with IDs (0, 3, 5, 9, 15, 16, 23),
     then this will apply a :class:`~torchio.RemapLabels` transform with
-    ``remapping={3: 1, 5: 2, 9: 3, 15: 4, 16: 5, 23: 6}``.
+    ``remapping={0: 0, 3: 1, 5: 2, 9: 3, 15: 4, 16: 5, 23: 6}``.
     This transformation is always `fully invertible <invertibility>`_.
 
     Args:
@@ -31,7 +31,7 @@ class SequentialLabels(LabelTransform):
             unique_labels = torch.unique(image.data)
             remapping = {
                 unique_labels[i].item(): i
-                for i in range(1, len(unique_labels))
+                for i in range(0, len(unique_labels))
             }
             transform = RemapLabels(
                 remapping=remapping,


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #840.

**Description**
The current mapping will map (3, 5, 9, 15, 16, 23) to {5: 1, 9: 2, 15: 3, 16: 4, 23: 5}, which is inconsistent with the documentation. And it can pass the test because in the testing procedure, when the label is generated, a 0 label will be added to it, and the 0 is the minimum in the label. But when we use an image as a label, if the minimum number is not 0, the `SequentialLabels` will cause a fatal bug.

I have no idea whether this is a non-breaking change, Only when the minimum number in label is 0 can lead to the same behavior with the edited `SequentialLabels`, but usually the minimum number in label is 0.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [ ] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [x] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
