### PR TITLE
Remove redundant GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,19 +11,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.6', '3.7', '3.8', '3.9']
 
     runs-on: ${{ matrix.os }}
     env:
       OS: ${{ matrix.os }}
-      PYTHON: ${{ matrix.python }}
 
     steps:
-      - name: Set up python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
-
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
@@ -31,9 +24,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Install dev requirements
-        run: pip install -r requirements-dev.txt
 
       - name: Run unit tests
         run: tox -e py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,11 @@ jobs:
       OS: ${{ matrix.os }}
 
     steps:
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
       - name: Upgrade pip
         run: python -m pip install --upgrade pip && pip install tox
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+        run: python -m pip install --upgrade pip && pip install tox
 
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: 3.9
 
       - name: Upgrade pip
-        run: python -m pip install --upgrade pip && pip install tox
+        run: pip install --upgrade pip && pip install tox codecov
 
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Currently, a matrix for Python 3.6, 3.7, 3.8 and 3.9 is created both by `tox` and GitHub actions. This means unit tests are run 16 times, instead of just 4 (I think). This leaves only the `tox` matrix, so tests are not run twice.