### PR TITLE
Fix new SimpleITK release not being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,15 @@ with open('README.md', encoding='utf8') as readme_file:
 with open('HISTORY.rst', encoding='utf8') as history_file:
     history = history_file.read()
 
+simple_itk_suffixes = (
+    '!=2.0.*',  # https://github.com/SimpleITK/SimpleITK/issues/1239
+    '!=2.1.1.1',  # https://github.com/fepegar/torchio/runs/5952172467
+)
+simple_itk_versions = ','.join(simple_itk_suffixes)
+
 requirements = [
     'Deprecated',
-    'SimpleITK!=2.0.*',  # https://github.com/SimpleITK/SimpleITK/issues/1239
+    f'SimpleITK{simple_itk_versions}',
     'click',
     'humanize',
     'nibabel',


### PR DESCRIPTION
The new version of SimpleITK, 2.1.1.1, is breaking the tests. This PR addresses the issue by preventing PIP to install this specific version.

Related to https://github.com/SimpleITK/SimpleITK/issues/1627
