### PR TITLE
Stop running duplicate tests when opening PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   push:
   pull_request:
+    types: [opened, reopened]
   schedule:
     - cron: "0 4 * * *"
 


### PR DESCRIPTION
Hopefully, this will avoid running tests twice every time a PR is opened.