### PR TITLE
Stop running duplicate tests when opening PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: "0 4 * * *"


### PR DESCRIPTION
Hopefully, this will avoid running tests twice every time a PR is opened (second try).