### PR TITLE
Add 5D tensor support and tensor dim. test

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -182,6 +182,18 @@ class TestImage(TorchioTestCase):
     def test_pil_3(self):
         tio.ScalarImage(tensor=torch.rand(3, 2, 3, 1)).as_pil()
 
+    def test_tensor_5d(self):
+        a = tio.ScalarImage(tensor=torch.rand(1, 2, 3, 3, 1))
+        subj_ = tio.Subject(a=a)
+        transforms_ = tio.Compose(
+            [tio.RescaleIntensity(out_min_max=(0, 1)),
+             tio.RandomAffine(), ])
+        tio.SubjectsDataset([subj_], transform=transforms_)
+
+    def test_tensor_bad_dim(self):
+        with self.assertRaises(ValueError):
+            tio.ScalarImage(tensor=torch.rand(1, 2, 3, 3, 1, 1))
+
     def test_set_data(self):
         with self.assertWarns(DeprecationWarning):
             im = self.sample_subject.t1

--- a/torchio/data/image.py
+++ b/torchio/data/image.py
@@ -452,8 +452,8 @@ class Image(dict):
             )
             raise TypeError(message)
         ndim = tensor.ndim
-        if ndim != 4:
-            raise ValueError(f'Input tensor must be 4D, but it is {ndim}D')
+        if ndim != 4 and ndim != 5:
+            raise ValueError(f'Input tensor must be 4D or 5D, but is {ndim}D')
         if tensor.dtype == torch.bool:
             tensor = tensor.to(torch.uint8)
         if self.check_nans and torch.isnan(tensor).any():


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Adds support for 5D tensors #203.

**Description**

Adding support for 5D tensors as input to a ```torchio.ScalarImage```

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [x] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
