### PR TITLE
return figure in plot_volume function

### DIFF
--- a/torchio/visualization.py
+++ b/torchio/visualization.py
@@ -105,6 +105,7 @@ def plot_volume(
         fig.savefig(output_path)
     if show:
         plt.show()
+    return fig
 
 
 def plot_subject(


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #865 .

**Description**
By returning the matplotlib figure it can by used for other purposes, for example sending it in an experiment tracker

**Checklist**

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
