### PR TITLE
Stop upgrading pip in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Unit tests and coverage
 
 on:
   push:
@@ -23,13 +23,13 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Upgrade pip
-        run: pip install --upgrade pip && pip install tox codecov
-
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Install tox
+        run: pip install tox codecov
 
       - name: Run unit tests
         run: tox -e py


### PR DESCRIPTION
Hopefully, this will stop the [daily tests from failing](https://github.com/fepegar/torchio/runs/6438720925?check_suite_focus=true).