### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,11 +45,11 @@ repos:
     hooks:
       - id: python-check-blanket-noqa  # enforce that noqa annotations always occur with specific codes
       - id: python-no-log-warn  # check for the deprecated .warn() method of python loggers
-      - id: python-use-type-annotations  # enforce that python3.6+ type annotations are used instead of type comments
+      - id: python-use-type-annotations  # enforce that type annotations are used instead of type comments
       - id: rst-backticks  # detect common mistake of using single backticks when writing rst
       # - id: rst-inline-touching-normal  # detect mistake of inline code touching normal text in rst
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.32.1
     hooks:
       - id: pyupgrade
-        args: ['--py36-plus']
+        args: ['--py37-plus']

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ requirements = [
 setup(
     author='Fernando Perez-Garcia',
     author_email='fepegar@gmail.com',
-    python_requires='>=7',
+    python_requires='>=3.7',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -32,13 +32,12 @@ requirements = [
 setup(
     author='Fernando Perez-Garcia',
     author_email='fepegar@gmail.com',
-    python_requires='>=3.6',
+    python_requires='>=7',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Science/Research',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36, 37, 38, 39, 310}
+envlist = py{37, 38, 39, 310}
 
 [testenv]
 deps =


### PR DESCRIPTION
[It’s time to stop using Python 3.6](https://pythonspeed.com/articles/stop-using-python-3.6/)!