### PR TITLE
add hann window function in GridAggregator as padding_mode

### DIFF
--- a/tests/data/inference/test_aggregator.py
+++ b/tests/data/inference/test_aggregator.py
@@ -49,6 +49,15 @@ class TestAggregator(TorchioTestCase):
         )).reshape(1, 1, 4, 4)
         self.aggregate('average', fixture)
 
+    def test_overlap_hann(self):
+        fixture = torch.Tensor((
+            (0, 2 / 3, 4 / 3, 2),
+            (4 / 3, 2, 8 / 3, 10 / 3),
+            (8 / 3, 10 / 3, 4, 14 / 3),
+            (4, 14 / 3, 16 / 3, 6),
+        )).reshape(1, 1, 4, 4)
+        self.aggregate('hann', fixture)
+
     def run_sampler_aggregator(self, overlap_mode='crop'):
         patch_size = 10
         patch_overlap = 2


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #894.

**Description**
Added hann window function as overlapping mode to GridAggregator.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
