### PR TITLE
Add support to mask 4D images with 3D masks

### DIFF
--- a/src/torchio/transforms/preprocessing/intensity/mask.py
+++ b/src/torchio/transforms/preprocessing/intensity/mask.py
@@ -17,9 +17,15 @@ class Mask(IntensityTransform):
             :class:`~torchio.transforms.preprocessing.intensity.NormalizationTransform`.
         outside_value: Value to set for all voxels outside of the mask.
         labels: If a label map is used to generate the mask,
-            sequence of labels to consider.
+            sequence of labels to consider. If ``None``, all values larger than
+            zero will be used for the mask.
         **kwargs: See :class:`~torchio.transforms.Transform` for additional
             keyword arguments.
+
+    Raises:
+        RuntimeWarning: If a 4D image is masked with a 3D mask, the mask will
+            be expanded along the channels (first) dimension, and a warning
+            will be raised.
 
     Example:
         >>> import torchio as tio

--- a/src/torchio/transforms/preprocessing/intensity/mask.py
+++ b/src/torchio/transforms/preprocessing/intensity/mask.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional, Sequence
 
 import torch
@@ -72,7 +73,16 @@ def mask(
         mask: torch.Tensor,
         outside_value: float,
 ) -> torch.Tensor:
-    array = tensor.clone().numpy()
-    mask = mask.numpy()
+    array = tensor.clone()
+    num_channels_array = array.shape[0]
+    num_channels_mask = mask.shape[0]
+    if num_channels_array != num_channels_mask:
+        assert num_channels_mask == 1
+        message = (
+            f'Expanding mask with shape {mask.shape}'
+            f' to match shape {array.shape} of input image'
+        )
+        warnings.warn(message, RuntimeWarning)
+        mask = mask.expand(*array.shape)
     array[~mask] = outside_value
-    return torch.as_tensor(array)
+    return array

--- a/tests/transforms/preprocessing/test_mask.py
+++ b/tests/transforms/preprocessing/test_mask.py
@@ -69,5 +69,6 @@ class TestMask(TorchioTestCase):
         mask = tio.LabelMap(tensor=torch.ones(1, 4, 5, 6))
         subject = tio.Subject(image=image, mask_lm=mask)
         transform = tio.Mask(masking_method='mask_lm')
-        masked = transform(subject)
-        assert masked.shape == image.shape
+        with self.assertWarnsRegex(RuntimeWarning, '^Expanding.*'):
+            masked = transform(subject)
+        assert masked.image.shape == image.shape

--- a/tests/transforms/preprocessing/test_mask.py
+++ b/tests/transforms/preprocessing/test_mask.py
@@ -63,3 +63,11 @@ class TestMask(TorchioTestCase):
         transform = tio.Mask(masking_method='label')
         transformed = transform(subject)
         assert (transformed.t1.data[masked_voxel_indices] == 0).all()
+
+    def test_4d(self):
+        image = tio.ScalarImage(tensor=torch.rand(3, 4, 5, 6))
+        mask = tio.LabelMap(tensor=torch.ones(1, 4, 5, 6))
+        subject = tio.Subject(image=image, mask_lm=mask)
+        transform = tio.Mask(masking_method='mask_lm')
+        masked = transform(subject)
+        assert masked.shape == image.shape


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #895.

**Description**
Add support to mask 4D images with 3D masks. At the moment, trying this raises an error.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [ ] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
