### PR TITLE
Add fftshift to fourier_transform with torch.fft

### DIFF
--- a/src/torchio/transforms/fourier.py
+++ b/src/torchio/transforms/fourier.py
@@ -8,7 +8,9 @@ class FourierTransform:
     def fourier_transform(tensor: torch.Tensor) -> torch.Tensor:
         try:
             import torch.fft
-            return torch.fft.fftn(tensor)
+            transformed = torch.fft.fftn(tensor)
+            fshift = torch.fft.fftshift(transformed)
+            return fshift
         except ModuleNotFoundError:
             import torch
             transformed = np.fft.fftn(tensor)
@@ -19,7 +21,9 @@ class FourierTransform:
     def inv_fourier_transform(tensor: torch.Tensor) -> torch.Tensor:
         try:
             import torch.fft
-            return torch.fft.ifftn(tensor)
+            f_ishift = torch.fft.ifftshift(tensor)
+            img_back = torch.fft.ifftn(f_ishift)
+            return img_back
         except ModuleNotFoundError:
             import torch
             f_ishift = np.fft.ifftshift(tensor)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #911

**Description**
This makes the behavior of fourier_transform and inv_fourier_transform
consistent with earlier versions of torchio. It is also independent of
whether torch or numpy is used to perform the transform.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [X] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [X] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [X] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [X] This pull request is ready to be reviewed
- [X] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
