### PR TITLE
Fix tox running on Python 3.7 only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -18,10 +19,10 @@ jobs:
       OS: ${{ matrix.os }}
 
     steps:
-      - name: Set up python
+      - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -29,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install tox
-        run: pip install tox codecov
+        run: pip install tox tox-gh-actions codecov
 
       - name: Run unit tests
         run: tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: pip install tox codecov
 
       - name: Run unit tests
-        run: tox -e py
+        run: tox
 
       - name: Upload coverage
         run: codecov

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,13 @@
 envlist = py{37, 38, 39, 310}
 isolated_build = True
 
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+
 [testenv]
 extras = dev
 commands =


### PR DESCRIPTION
Tests were being run on Python 3.10 only. This makes CI run tests on Python 3.7 to 3.10.