### PR TITLE
Fix non-shuffling Queue minibatch pop order

### DIFF
--- a/src/torchio/data/queue.py
+++ b/src/torchio/data/queue.py
@@ -171,7 +171,7 @@ class Queue(Dataset):
         if not self.patches_list:
             self._print('Patches list is empty.')
             self._fill()
-        sample_patch = self.patches_list.pop()
+        sample_patch = self.patches_list.pop(0)
         self.num_sampled_patches += 1
         return sample_patch
 

--- a/tests/data/test_queue.py
+++ b/tests/data/test_queue.py
@@ -92,7 +92,7 @@ class TestQueue(TorchioTestCase):
             batch_size=3,
             shuffle=False,
             num_workers=0,
-            drop_last=False
+            drop_last=False,
         )
         self.assertEqual(
             list(range(len(queue_dataset))),

--- a/tests/data/test_queue.py
+++ b/tests/data/test_queue.py
@@ -85,11 +85,13 @@ class TestQueue(TorchioTestCase):
             sampler=sampler,
             num_workers=2,
             shuffle_subjects=False,
-            shuffle_patches=False
+            shuffle_patches=False,
         )
         batch_loader = DataLoader(queue_dataset, batch_size=3, shuffle=False, num_workers=0, drop_last=False)
-        self.assertEqual(list(range(len(queue_dataset))),
-                         [x['ID'] for x in subjects_dataset])
+        self.assertEqual(
+            list(range(len(queue_dataset))),
+            [x['ID'] for x in subjects_dataset],
+        )
         queue_dataset.patches_list.clear()
         queue_dataset._initialize_subjects_iterable()
         sequential_idlist = []
@@ -97,12 +99,16 @@ class TestQueue(TorchioTestCase):
             if i == len(subjects_dataset):
                 break
             sequential_idlist.append(mb['ID'])
-        self.assertEqual(list(range(len(subjects_dataset))),
-                         sequential_idlist)
+        self.assertEqual(
+            list(range(len(subjects_dataset))),
+            sequential_idlist,
+        )
         queue_dataset.patches_list.clear()
         queue_dataset._initialize_subjects_iterable()
         sequential_idlist = []
         for mb in batch_loader:
             sequential_idlist.extend(mb['ID'])
-        self.assertEqual(list(range(len(subjects_dataset))),
-                         sequential_idlist)
+        self.assertEqual(
+            list(range(len(subjects_dataset))),
+            sequential_idlist,
+        )

--- a/tests/data/test_queue.py
+++ b/tests/data/test_queue.py
@@ -87,7 +87,13 @@ class TestQueue(TorchioTestCase):
             shuffle_subjects=False,
             shuffle_patches=False,
         )
-        batch_loader = DataLoader(queue_dataset, batch_size=3, shuffle=False, num_workers=0, drop_last=False)
+        batch_loader = DataLoader(
+            queue_dataset,
+            batch_size=3,
+            shuffle=False,
+            num_workers=0,
+            drop_last=False
+        )
         self.assertEqual(
             list(range(len(queue_dataset))),
             [x['ID'] for x in subjects_dataset],


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #938.

**Description**
Fixed mini-batch sampling order when the `shuffle_subjects` is set to `False` for `tio.Queue`.
Added a test case to verify this change. 

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)

## Notes
I would let you decide whether you want to have the unittest merged in a second commit. 