### PR TITLE
Add support to pass a callable as padding mode

### DIFF
--- a/src/torchio/transforms/preprocessing/spatial/pad.py
+++ b/src/torchio/transforms/preprocessing/spatial/pad.py
@@ -69,10 +69,11 @@ class Pad(BoundsTransform):
     @classmethod
     def check_padding_mode(cls, padding_mode):
         is_number = isinstance(padding_mode, Number)
-        if not (padding_mode in cls.PADDING_MODES or is_number):
+        is_callable = callable(padding_mode)
+        if not (padding_mode in cls.PADDING_MODES or is_number or is_callable):
             message = (
                 f'Padding mode "{padding_mode}" not valid. Valid options are'
-                f' {list(cls.PADDING_MODES)} or a number'
+                f' {list(cls.PADDING_MODES)}, a number or a function'
             )
             raise KeyError(message)
 

--- a/tests/transforms/preprocessing/test_pad.py
+++ b/tests/transforms/preprocessing/test_pad.py
@@ -24,3 +24,13 @@ class TestPad(TorchioTestCase):
         padded = tio.Pad(1, padding_mode=2)(self.sample_subject)
         again = padded.history[0](self.sample_subject)
         assert not torch.isnan(again.t1.data).any()
+
+    def test_padding_modes(self):
+        def padding_func():
+            return
+
+        for padding_mode in [0, *tio.Pad.PADDING_MODES, padding_func]:
+            tio.Pad(0, padding_mode=padding_mode)
+
+        with self.assertRaises(KeyError):
+            tio.Pad(0, padding_mode='abc')


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #957.

**Description**
It fixes the KeyError message when a function is passed as `padding_mode` in the `Pad` class. 

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
