### PR TITLE
"Transforms" instead of "Images" in documentation under transforms>composability

### DIFF
--- a/docs/source/transforms/transforms.rst
+++ b/docs/source/transforms/transforms.rst
@@ -49,7 +49,7 @@ All transforms inherit from :class:`torchio.transforms.Transform`:
 Composability
 -------------
 
-Images can be composed to create directed acyclic graphs defining the
+Transforms can be composed to create directed acyclic graphs defining the
 probability that each transform will be applied.
 
 For example, to obtain the following graph:


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #955.

**Description**
Changed the word "Images" into "Transforms" as it better fits the phrase

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
