### PR TITLE
Catch fourier AttributeError when pytorch version < 1.8.0

### DIFF
--- a/src/torchio/transforms/fourier.py
+++ b/src/torchio/transforms/fourier.py
@@ -11,7 +11,7 @@ class FourierTransform:
             transformed = torch.fft.fftn(tensor)
             fshift = torch.fft.fftshift(transformed)
             return fshift
-        except ModuleNotFoundError:
+        except (ModuleNotFoundError, AttributeError):
             import torch
             transformed = np.fft.fftn(tensor)
             fshift = np.fft.fftshift(transformed)
@@ -24,7 +24,7 @@ class FourierTransform:
             f_ishift = torch.fft.ifftshift(tensor)
             img_back = torch.fft.ifftn(f_ishift)
             return img_back
-        except ModuleNotFoundError:
+        except (ModuleNotFoundError, AttributeError):
             import torch
             f_ishift = np.fft.ifftshift(tensor)
             img_back = np.fft.ifftn(f_ishift)


### PR DESCRIPTION
<!-- Replace {967} with the issue that will be closed after merging this PR -->
Fixes [#967](https://github.com/fepegar/torchio/issues/967).

**Description**
Catch AttributeError in fourier.py, fftshift is not implemented in torch.fft when pytorch version < 1.8.0

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [x] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
