### PR TITLE
Fix number of samples per subject in queue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ dev =
     matplotlib
     mypy
     pandas-stubs
+    parametrize
     pre-commit
     pytest
     pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ dev =
     matplotlib
     mypy
     pandas-stubs
-    parametrize
+    parameterized
     pre-commit
     pytest
     pytest-cov

--- a/tests/data/test_queue.py
+++ b/tests/data/test_queue.py
@@ -1,3 +1,4 @@
+from parameterized import parameterized
 import torch
 import torchio as tio
 from torch.utils.data import DataLoader
@@ -47,7 +48,8 @@ class TestQueue(TorchioTestCase):
     def test_queue_no_start_background(self):
         self.run_queue(num_workers=0, start_background=False)
 
-    def test_different_samples_per_volume(self):
+    @parameterized.expand([(11,), (12,)])
+    def test_different_samples_per_volume(self, max_length):
         image2 = tio.ScalarImage(tensor=2 * torch.ones(1, 1, 1, 1))
         image10 = tio.ScalarImage(tensor=10 * torch.ones(1, 1, 1, 1))
         subject2 = tio.Subject(im=image2, num_samples=2)
@@ -57,7 +59,7 @@ class TestQueue(TorchioTestCase):
         sampler = UniformSampler(patch_size)
         queue_dataset = tio.Queue(
             dataset,
-            max_length=12,
+            max_length=max_length,
             samples_per_volume=3,  # should be ignored
             sampler=sampler,
         )


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #979.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
