### PR TITLE
Use indexing instead of masked_select for faster normalization

### DIFF
--- a/src/torchio/transforms/preprocessing/intensity/z_normalization.py
+++ b/src/torchio/transforms/preprocessing/intensity/z_normalization.py
@@ -49,7 +49,7 @@ class ZNormalization(NormalizationTransform):
             mask: torch.Tensor,
     ) -> Optional[torch.Tensor]:
         tensor = tensor.clone().float()
-        values = tensor.masked_select(mask)
+        values = tensor[mask]
         mean, std = values.mean(), values.std()
         if std == 0:
             return None


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #1017.

**Description**
Uses indexing instead of `masked_select` for faster normalization.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
