### PR TITLE
Disable Windows tests on Python 3.10 temporarily

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,8 @@ jobs:
             python-version: '3.8'
           - os: windows-latest
             python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.10'
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This should be reverted once the following is fixed:
- #1014

