### PR TITLE
Fix silenced exception in Queue when using faulty transform

### DIFF
--- a/src/torchio/data/queue.py
+++ b/src/torchio/data/queue.py
@@ -328,6 +328,7 @@ class Queue(Dataset):
                     ' patches from the queue should be 0. Is it?'
                 )
                 raise RuntimeError(message) from exception
+            raise exception
         return subject
 
     @staticmethod


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->

Fixes #1098.

**Description**

<!-- Write a few sentences describing the changes proposed in this pull request. -->
Fixed a bug where a faulty (e.g.: custom) transform used in a Queue would throw an error that would be caught by a try / except statement  but ignored, causing an UnboundLocalError. This error did not give any information on the original exception, making it harder to understand that the origin of the problem is a faulty transform.

This PR makes the Queue raises the original exception

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [ x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x ] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [ x] This pull request is ready to be reviewed
