### PR TITLE
Fix type hints in RandomMotion

### DIFF
--- a/src/torchio/transforms/augmentation/intensity/random_motion.py
+++ b/src/torchio/transforms/augmentation/intensity/random_motion.py
@@ -52,8 +52,8 @@ class RandomMotion(RandomTransform, IntensityTransform, FourierTransform):
 
     def __init__(
         self,
-        degrees: Union[float, Tuple[float, float] = 10,
-        translation: Union[float, Tuple[float, float] = 10,  # in mm
+        degrees: Union[float, Tuple[float, float]] = 10,
+        translation: Union[float, Tuple[float, float]] = 10,  # in mm
         num_transforms: int = 2,
         image_interpolation: str = 'linear',
         **kwargs,

--- a/src/torchio/transforms/augmentation/intensity/random_motion.py
+++ b/src/torchio/transforms/augmentation/intensity/random_motion.py
@@ -52,8 +52,8 @@ class RandomMotion(RandomTransform, IntensityTransform, FourierTransform):
 
     def __init__(
         self,
-        degrees: float = 10,
-        translation: float = 10,  # in mm
+        degrees: Union[float, Tuple[float, float] = 10,
+        translation: Union[float, Tuple[float, float] = 10,  # in mm
         num_transforms: int = 2,
         image_interpolation: str = 'linear',
         **kwargs,


### PR DESCRIPTION
**Description**

Fix type hints in the `RandomMotion` `__init__` method, which should allow for tuples of floats in `degrees` and `translation`. This type hint now matches the docstring.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [x] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
