### PR TITLE
Enable plotting of PNG images with alpha channel

### DIFF
--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -674,8 +674,8 @@ class Image(dict):
         tensor = self.data
         if len(tensor) == 1:
             tensor = torch.cat(3 * [tensor])
-        if len(tensor) != 3:
-            raise RuntimeError('The image must have 1 or 3 channels')
+        if not (len(tensor) == 3 or len(tensor) == 4):
+            raise RuntimeError('The image must have 1, 3 or 4 channels')
         if transpose:
             tensor = tensor.permute(3, 2, 1, 0)
         else:

--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -686,7 +686,7 @@ class Image(dict):
     def to_gif(
         self,
         axis: int,
-        duration: float,  # of full gif
+        duration: float,  # of full gif 
         output_path: TypePath,
         loop: int = 0,
         rescale: bool = True,

--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -686,7 +686,7 @@ class Image(dict):
     def to_gif(
         self,
         axis: int,
-        duration: float,  # of full gif 
+        duration: float,  # of full gif
         output_path: TypePath,
         loop: int = 0,
         rescale: bool = True,


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->

Fixes #724

**Description**

`ImagePIL.fromarray` accepts and correctly interprets the fourth channel of a png-derived tensor as an alpha channel. I believe that simply allowing for four channels should do the trick. I have tested on a single image with alpha channel. 

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
