### PR TITLE
Documentation for "isotropic" in random affine transform

### DIFF
--- a/src/torchio/transforms/augmentation/spatial/random_affine.py
+++ b/src/torchio/transforms/augmentation/spatial/random_affine.py
@@ -70,6 +70,10 @@ class RandomAffine(RandomTransform, SpatialTransform):
             10 mm to the back, 20 mm downwards, and 30 mm to the right.
         isotropic: If ``True``, the scaling factor along all dimensions is the
             same, i.e. :math:`s_1 = s_2 = s_3`.
+            If one value provided in :attr:`scales`, the scaling factor will be 
+            :math:`s_i \sim \mathcal{U}(1 - x, 1 + x)`.
+            If two values provided in :attr:`scales`, the scaling factor will be 
+            :math:`s_i \sim \mathcal{U}(x_1, x_2)`.
         center: If ``'image'``, rotations and scaling will be performed around
             the image center. If ``'origin'``, rotations and scaling will be
             performed around the origin in world coordinates.
@@ -442,7 +446,9 @@ def _parse_scales_isotropic(scales, isotropic):
     if isotropic and len(scales) in (3, 6):
         message = (
             'If "isotropic" is True, the value for "scales" must have'
-            f' length 1 or 2, but "{scales}" was passed'
+            f' length 1 or 2, but "{scales}" was passed.'
+            ' If you want to set isotropic scaling, use a single value or two values as a range for scaling factor.'
+            ' Refer to the documentation for more information.'
         )
         raise ValueError(message)
 

--- a/src/torchio/transforms/augmentation/spatial/random_affine.py
+++ b/src/torchio/transforms/augmentation/spatial/random_affine.py
@@ -70,9 +70,9 @@ class RandomAffine(RandomTransform, SpatialTransform):
             10 mm to the back, 20 mm downwards, and 30 mm to the right.
         isotropic: If ``True``, the scaling factor along all dimensions is the
             same, i.e. :math:`s_1 = s_2 = s_3`.
-            If one value provided in :attr:`scales`, the scaling factor will be 
+            If one value provided in :attr:`scales`, the scaling factor will be
             :math:`s_i \sim \mathcal{U}(1 - x, 1 + x)`.
-            If two values provided in :attr:`scales`, the scaling factor will be 
+            If two values provided in :attr:`scales`, the scaling factor will be
             :math:`s_i \sim \mathcal{U}(x_1, x_2)`.
         center: If ``'image'``, rotations and scaling will be performed around
             the image center. If ``'origin'``, rotations and scaling will be


### PR DESCRIPTION
As discussed in #1158, additinal documentation is added to prevent confusion when "isotropic" is true and "scales" has more than 2 elements.

<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->

Fixes #1158.

**Description**

<!-- Write a few sentences describing the changes proposed in this pull request. -->

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [x] In-line docstrings updated
- [x] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
