### PR TITLE
Set upper bound of PyTorch version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     nibabel
     numpy>=1.15
     scipy
-    torch>=1.1
+    torch>=1.1,<2.3
     tqdm
     typer[all]
 python_requires = >=3.8, <3.13

--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 import torch
 import torchio as tio
+from torch.utils.data import DataLoader
 
 from ..utils import TorchioTestCase
 
@@ -175,3 +176,9 @@ class TestSubject(TorchioTestCase):
         self.sample_subject.unload()
         for image in self.sample_subject.get_images(intensity_only=False):
             assert not image._loaded
+
+    def test_subjects_batch(self):
+        subjects = tio.SubjectsDataset(10 * [self.sample_subject])
+        loader = DataLoader(subjects, batch_size=4)
+        batch = next(iter(loader))
+        assert batch.__class__ is dict


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->


**Description**

<!-- Write a few sentences describing the changes proposed in this pull request. -->

This doesn't work

```python
import torch
import torchio as tio

subject = tio.datasets.Colin27()
subject.load()
subjects = 10 * [subject]

from torch.utils.data import DataLoader
loader = DataLoader(subjects, batch_size=4)
batch = next(iter(loader))
batch.__class__ is dict
```

because `batch` is an instance of `Subject`.

This happens in PyTorch >=2.3 because of
- https://github.com/pytorch/pytorch/pull/120553

This PR forces PyTorch to be <2.3, temporarily.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
