### PR TITLE
Make transform return the same type as input

### DIFF
--- a/src/torchio/transforms/transform.py
+++ b/src/torchio/transforms/transform.py
@@ -9,6 +9,7 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from typing import TypeVar
 from typing import Union
 
 import numpy as np
@@ -48,6 +49,8 @@ ANATOMICAL_AXES = (
     'Inferior',
     'Superior',
 )
+
+InputType = TypeVar('InputType', bound=TypeTransformInput)
 
 
 class Transform(ABC):
@@ -127,8 +130,8 @@ class Transform(ABC):
 
     def __call__(
         self,
-        data: TypeTransformInput,
-    ) -> TypeTransformInput:
+        data: InputType,
+    ) -> InputType:
         """Transform data and return a result of the same type.
 
         Args:


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->


**Description**

<!-- Write a few sentences describing the changes proposed in this pull request. -->

Transform call currently returns a new type `TypeTransformInput`. This PR makes a generic type bound by the original `TypeTransformInput` so that type checkers know the same type is being returned.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
