### PR TITLE
Set upper bound of NumPy version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     SimpleITK!=2.0.*,!=2.1.1.1
     humanize
     nibabel
-    numpy>=1.15
+    numpy>=1.15,<2
     scipy
     torch>=1.1,<2.3
     tqdm


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->

**Description**

<!-- Write a few sentences describing the changes proposed in this pull request. -->

The CI tests are [failing](https://github.com/fepegar/torchio/actions/runs/9707270027/job/26792204078) because NumPy 2 and PyTorch 2.2 don't seem to be compatible:

```python
>>> import numpy
>>> import torch
```

```python-traceback
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "<stdin>", line 1, in <module>
  File "/Users/fernando/miniforge3/envs/test/lib/python3.11/site-packages/torch/__init__.py", line 1477, in <module>
    from .functional import *  # noqa: F403
  File "/Users/fernando/miniforge3/envs/test/lib/python3.11/site-packages/torch/functional.py", line 9, in <module>
    import torch.nn.functional as F
  File "/Users/fernando/miniforge3/envs/test/lib/python3.11/site-packages/torch/nn/__init__.py", line 1, in <module>
    from .modules import *  # noqa: F403
  File "/Users/fernando/miniforge3/envs/test/lib/python3.11/site-packages/torch/nn/modules/__init__.py", line 35, in <module>
    from .transformer import TransformerEncoder, TransformerDecoder, \
  File "/Users/fernando/miniforge3/envs/test/lib/python3.11/site-packages/torch/nn/modules/transformer.py", line 20, in <module>
    device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
/Users/fernando/miniforge3/envs/test/lib/python3.11/site-packages/torch/nn/modules/transformer.py:20: UserWarning: Failed to initialize NumPy: _ARRAY_API not found (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
  device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
```
