### PR TITLE
Fix error which copying a subclass of Subject with keyword attributes

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -806,16 +806,6 @@
       "contributions": [
         "code"
       ]
-    },
-    {
-      "login": "c-winder",
-      "name": "Chris Winder",
-      "avatar_url": "https://avatars.githubusercontent.com/u/50587864?v=4",
-      "profile": "https://https://github.com/c-winder",
-      "contributions": [
-        "code",
-        "bug"
-      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -806,6 +806,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "c-winder",
+      "name": "Chris Winder",
+      "avatar_url": "https://avatars.githubusercontent.com/u/50587864?v=4",
+      "profile": "https://https://github.com/c-winder",
+      "contributions": [
+        "code",
+        "bug"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/src/torchio/data/subject.py
+++ b/src/torchio/data/subject.py
@@ -442,7 +442,7 @@ def _subject_copy_helper(
             value = copy.deepcopy(value)
         result_dict[key] = value
 
-    new = new_subj_cls(result_dict)
+    new = new_subj_cls(**result_dict)
     new.applied_transforms = old_obj.applied_transforms[:]
     return new
 

--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -163,7 +163,7 @@ class TestSubject(TorchioTestCase):
                 super().__init__(**kwargs)
 
         dummy_sub = DummySubjectSubClass(
-            attr_1='abcd',
+            attr_1="abcd",
             attr_2=tio.ScalarImage(tensor=torch.zeros(1, 1, 1, 1)),
         )
         sub_copy = copy.copy(dummy_sub)

--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -159,8 +159,8 @@ class TestSubject(TorchioTestCase):
 
     def test_copy_subclass(self):
         class DummySubjectSubClass(tio.data.Subject):
-            def __init__(self, attr_1, attr_2):
-                super().__init__(attr_1=attr_1, attr_2=attr_2)
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
 
         dummy_sub = DummySubjectSubClass(
             attr_1='abcd', attr_2=tio.ScalarImage(tensor=torch.zeros(1, 1, 1, 1))

--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -159,9 +159,12 @@ class TestSubject(TorchioTestCase):
 
     def test_copy_subclass(self):
         class DummySubjectSubClass(tio.data.Subject):
-            pass
+            def __init__(self, attr_1, attr_2):
+                super().__init__(attr_1=attr_1, attr_2=attr_2)
 
-        dummy_sub = DummySubjectSubClass(self.sample_subject)
+        dummy_sub = DummySubjectSubClass(
+            attr_1='abcd', attr_2=tio.ScalarImage(tensor=torch.zeros(1, 1, 1, 1))
+        )
         sub_copy = copy.copy(dummy_sub)
         assert isinstance(sub_copy, tio.data.Subject)
         assert isinstance(sub_copy, DummySubjectSubClass)

--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -163,7 +163,7 @@ class TestSubject(TorchioTestCase):
                 super().__init__(**kwargs)
 
         dummy_sub = DummySubjectSubClass(
-            attr_1="abcd",
+            attr_1='abcd',
             attr_2=tio.ScalarImage(tensor=torch.zeros(1, 1, 1, 1)),
         )
         sub_copy = copy.copy(dummy_sub)

--- a/tests/data/test_subject.py
+++ b/tests/data/test_subject.py
@@ -163,7 +163,8 @@ class TestSubject(TorchioTestCase):
                 super().__init__(**kwargs)
 
         dummy_sub = DummySubjectSubClass(
-            attr_1='abcd', attr_2=tio.ScalarImage(tensor=torch.zeros(1, 1, 1, 1))
+            attr_1='abcd',
+            attr_2=tio.ScalarImage(tensor=torch.zeros(1, 1, 1, 1)),
         )
         sub_copy = copy.copy(dummy_sub)
         assert isinstance(sub_copy, tio.data.Subject)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->

Fixes #1181.

Updated Subject._subject_copy_helper to unpack the dictionary of attributes rather than passing it directly. This means that a subclass of Subject will correctly read any keyword arguments in the dict rather than passing the entire unpacked dict to the first argument.

test_copy_subclass has been extended to test that this works properly. The dummy subclass now has two attributes.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
