### PR TITLE
Add warning if SubjectsLoader is not used in PyTorch >= 2.3

### DIFF
--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -36,6 +36,7 @@ from ..typing import TypeTripletFloat
 from ..typing import TypeTripletInt
 from ..utils import get_stem
 from ..utils import guess_external_viewer
+from ..utils import in_torch_loader
 from ..utils import is_iterable
 from ..utils import to_tuple
 from .io import check_uint_to_int
@@ -176,6 +177,15 @@ class Image(dict):
             warnings.warn(message, DeprecationWarning, stacklevel=2)
 
         super().__init__(**kwargs)
+        if torch.__version__ >= '2.3' and in_torch_loader():
+            message = (
+                'Using TorchIO images without a SubjectsLoader in PyTorch >='
+                ' 2.3 might have unexpected consequences. Please replace your'
+                ' PyTorch DataLoader with a SubjectsLoader. See'
+                ' https://github.com/fepegar/torchio/issues/1179 for more'
+                ' context about this problem'
+            )
+            warnings.warn(message, stacklevel=1)
         self.path = self._parse_path(path)
 
         self[PATH] = '' if self.path is None else str(self.path)

--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -177,15 +177,7 @@ class Image(dict):
             warnings.warn(message, DeprecationWarning, stacklevel=2)
 
         super().__init__(**kwargs)
-        if torch.__version__ >= '2.3' and in_torch_loader():
-            message = (
-                'Using TorchIO images without a SubjectsLoader in PyTorch >='
-                ' 2.3 might have unexpected consequences. Please replace your'
-                ' PyTorch DataLoader with a SubjectsLoader. See'
-                ' https://github.com/fepegar/torchio/issues/1179 for more'
-                ' context about this problem'
-            )
-            warnings.warn(message, stacklevel=1)
+        self._check_data_loader()
         self.path = self._parse_path(path)
 
         self[PATH] = '' if self.path is None else str(self.path)
@@ -243,6 +235,20 @@ class Image(dict):
             **kwargs,
         )
         return new_image
+
+    @staticmethod
+    def _check_data_loader() -> None:
+        if torch.__version__ >= '2.3' and in_torch_loader():
+            message = (
+                'Using TorchIO images without a torchio.SubjectsLoader in PyTorch >='
+                ' 2.3 might have unexpected consequences, e.g., the collated batches'
+                ' will be instances of torchio.Subject with 5D images. Replace'
+                ' your PyTorch DataLoader with a torchio.SubjectsLoader so that'
+                ' the collated batch becomes a dictionary, as expected. See'
+                ' https://github.com/fepegar/torchio/issues/1179 for more'
+                ' context about this issue.'
+            )
+            warnings.warn(message, stacklevel=1)
 
     @property
     def data(self) -> torch.Tensor:

--- a/src/torchio/utils.py
+++ b/src/torchio/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import gzip
+import inspect
 import os
 import shutil
 import sys
@@ -19,6 +20,7 @@ from typing import Union
 import numpy as np
 import SimpleITK as sitk
 import torch
+import torch.utils.data.dataloader
 from nibabel.nifti1 import Nifti1Image
 from torch.utils.data import DataLoader
 from torch.utils.data._utils.collate import default_collate
@@ -415,3 +417,24 @@ def is_iterable(object: Any) -> bool:
         return True
     except TypeError:
         return False
+
+
+def in_class(classes) -> bool:
+    classes = to_tuple(classes)
+    stack = inspect.stack()
+    for frame_info in stack:
+        instance = frame_info.frame.f_locals.get('self')
+        if instance is None:
+            continue
+        if instance.__class__ in classes:
+            return True
+    else:
+        return False
+
+
+def in_torch_loader() -> bool:
+    classes = (
+        torch.utils.data.dataloader._SingleProcessDataLoaderIter,
+        torch.utils.data.dataloader._MultiProcessingDataLoaderIter,
+    )
+    return in_class(classes)


### PR DESCRIPTION
```python
import torch
import torchio as tio

colin = tio.datasets.Colin27()
dataset = tio.SubjectsDataset([colin])
```

```python
loader = torch.utils.data.DataLoader(dataset, batch_size=1)
next(iter(loader))
```

```
[/Users/fernando/git/torchio/src/torchio/data/image.py:188): UserWarning: Using TorchIO images without a SubjectsLoader in PyTorch >= 2.3 might have unexpected consequences. Please replace your PyTorch DataLoader with a SubjectsLoader. See https://github.com/fepegar/torchio/issues/1179 for more context about this problem
  warnings.warn(message, stacklevel=1)
Subject(Keys: ('t1', 'head', 'brain'); images: 3)
```

```python
loader = tio.SubjectsLoader(dataset, batch_size=1)
next(iter(loader))
```

```
{
    't1': {
        'path': ['/Users/fernando/.cache/torchio/mni_colin27_1998_nifti/colin27_t1_tal_lin.nii.gz'],
        'stem': ['colin27_t1_tal_lin'],
        'type': ['intensity'],
        'data': tensor([[[[[210684.4219, 225600.1250, 231532.5156,  ...,      0.0000,
                 0.0000,      0.0000],
           [250516.1406, 225600.1250, 219837.2188,  ...,      0.0000,
                 0.0000,      0.0000],
           [241236.2031, 216532.0469, 222167.8125,  ...,      0.0000,
                 0.0000,      0.0000],
           ...,
           [236576.5156, 239396.7031, 224654.7500,  ...,      0.0000,
                 0.0000,      0.0000],
           [229333.7188, 204913.3281, 226833.9844,  ...,      0.0000,
                 0.0000,      0.0000],
           [187158.8750, 165750.9844, 201131.6875,  ...,      0.0000,
                 0.0000,      0.0000]]]]]),
        'affine': array([[[   1.,    0.,    0.,  -90.],
        [   0.,    1.,    0., -126.],
        [   0.,    0.,    1.,  -72.],
        [   0.,    0.,    0.,    1.]]])
...
        [   0.,    1.,    0., -126.],
        [   0.,    0.,    1.,  -72.],
        [   0.,    0.,    0.,    1.]]])
    }
}
```