### PR TITLE
Lazy image

### DIFF
--- a/src/torchio/__init__.py
+++ b/src/torchio/__init__.py
@@ -16,6 +16,9 @@ from .data import LabelMap
 from .data import LabelSampler
 from .data import Queue
 from .data import ScalarImage
+from .data import LazyImage
+from .data import LazyScalarImage
+from .data import LazyLabelMap
 from .data import Subject
 from .data import SubjectsDataset
 from .data import SubjectsLoader
@@ -36,6 +39,9 @@ __all__ = [
     'Image',
     'ScalarImage',
     'LabelMap',
+    'LazyImage',
+    'LazyScalarImage',
+    'LazyLabelMap',
     'Queue',
     'Subject',
     'datasets',

--- a/src/torchio/data/__init__.py
+++ b/src/torchio/data/__init__.py
@@ -2,6 +2,9 @@ from .dataset import SubjectsDataset
 from .image import Image
 from .image import LabelMap
 from .image import ScalarImage
+from .image import LazyImage
+from .image import LazyScalarImage
+from .image import LazyLabelMap
 from .inference import GridAggregator
 from .loader import SubjectsLoader
 from .queue import Queue
@@ -20,6 +23,9 @@ __all__ = [
     'Image',
     'ScalarImage',
     'LabelMap',
+    'LazyImage',
+    'LazyScalarImage',
+    'LazyLabelMap',
     'GridSampler',
     'GridAggregator',
     'PatchSampler',

--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -920,3 +920,77 @@ class LabelMap(Image):
         counter = Counter(values_list)
         counts = {label: counter[label] for label in sorted(counter)}
         return counts
+
+
+class LazyImage(Image):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def load(self):
+
+        if self._is_multipath():
+            message = (f'No multiple paths for LazyImage')
+            RuntimeError(message)
+
+        tensor, affine = self.read_and_check(self.path)
+        self.set_data(tensor)
+        self.affine = affine
+        self._loaded = True
+
+    def _parse_tensor(
+        self,
+        tensor: Optional[TypeData],
+        none_ok: bool = True,
+    ) -> Optional[torch.Tensor]:
+
+        if tensor is None:
+            if none_ok:
+                return None
+            else:
+                raise RuntimeError('Input tensor cannot be None')
+
+        ndim = tensor.ndim
+        if ndim != 4:
+            raise ValueError(f'Input tensor must be 4D, but it is {ndim}D')
+
+        return tensor
+
+    @staticmethod
+    def _parse_tensor_shape(tensor: torch.Tensor) -> TypeData:
+        # here we do not want to maniulate the whole data as tensor, to avoid loading
+        # so we skip check here, so we can not repare bad shape ...
+        # _parse_tensor, is already checking if ndim==4
+        return tensor
+
+    def __repr__(self):
+        # alternative would be to modify the __repr__ function of parent class (image
+        # in order to avoid the call self.data.type() (which is only defined for tensor)
+        properties = []
+        properties.extend(
+            [
+                f'shape: {self.shape}',
+                f'spacing: {self.get_spacing_string()}',
+                f'orientation: {"".join(self.orientation)}+',
+            ]
+        )
+        if self._loaded:
+            # instead of adding dtype and memory, just print the data
+            properties.append(f'dtype: {self.data}')
+        else:
+            properties.append(f'path: "{self.path}"')
+
+        properties = '; '.join(properties)
+        string = f'{self.__class__.__name__}({properties})'
+        return string
+
+
+class LazyScalarImage(LazyImage, ScalarImage):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+class LazyLabelMap(LazyImage, LabelMap):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/src/torchio/transforms/preprocessing/spatial/crop.py
+++ b/src/torchio/transforms/preprocessing/spatial/crop.py
@@ -1,5 +1,6 @@
 import nibabel as nib
 import numpy as np
+import torch
 
 from ....data.subject import Subject
 from .bounds_transform import BoundsTransform
@@ -48,7 +49,10 @@ class Crop(BoundsTransform):
             new_affine[:3, 3] = new_origin
             i0, j0, k0 = index_ini
             i1, j1, k1 = index_fin
-            image.set_data(image.data[:, i0:i1, j0:j1, k0:k1].clone())
+            if isinstance(image.data,torch.Tensor):
+                image.set_data(image.data[:, i0:i1, j0:j1, k0:k1].clone())
+            else:
+                image.set_data(torch.as_tensor(image.data[:, i0:i1, j0:j1, k0:k1]))
             image.affine = new_affine
         return sample
 


### PR DESCRIPTION

Fixes #328  #1224

**Description**
Allow lazy loading, as describe previously (especially recently in #1224)

The previous PR #328 was intended to do so, but was never merged to the main, instead this pull request  #454 was added in order to let the user defined is onw format (so including hdf5 for instance), 

This is nice, since it avoid to add extra dependency (like h5py ). But it assume, the custom reader, will end up with a full tensor.  Here we need to avoid reading the whole image, 

The idea with this lazyImage class is not to use any transform (because most tranforms would require to load the whole volume) but just to be use a sampler.
Once we get patches, one can then use any transform



```
import torchio as tio, torch, numpy as np
import h5py

#create a random hdf5 image
new_shape  = [1000,1000,1000]
file_out = h5py.File("random_int.hdf5", "w")
hdf5_data = file_out.create_dataset("data", [1] + new_shape , dtype='i')
hdf5_affine = file_out.create_dataset("affine", [4,4]) 
hdf5_affine[:] = np.eye(4)
hdf5_data[:] = np.random.randint(1,100,[1] + new_shape )
del hdf5_data , file_out

#read and test lazy loading
def read_hdf5(path, data_key='data', affine_key='affine'):
    file_out = h5py.File(path, "r")
    hdf5_data = file_out[data_key]        # do not read from disk
    hdf5_affine = file_out[affine_key][:] # read all from disk
    return hdf5_data, hdf5_affine

f_in = "random_int.hdf5"
img = tio.LazyScalarImage(f_in, reader=read_hdf5)
suj_hdf5 = tio.Subject({'t1': img })
sampler = tio.data.GridSampler(suj_hdf5,256,0)

# get patches, without loading the whole volume !!! 
for nump, one_patch in enumerate(sampler): #no DataLoader so that we keep Subject (no batch dimentsion)
    locations = one_patch[tio.LOCATION]
    print(f'P {nump} loc {locations}')

```


<!-- Write a few sentences describing the changes proposed in this pull request. -->

every thing was almost already working out of the box, the important  change I had to make is for the Image.load function: We do not allow multiple path since it would require a torch.cat

changes related to   _parse_tensor  _parse_tensor_shape are juste to avoid line expecting torch.tensor so we may make less check here but it is a good start
same for __repr__ function, change are only for memory and dtyp attribute

finally important change in crop function to make it work without tensor (just indexed array), (almost nothing since we are no more  dependent on stik here !!!) 

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x ] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [ x] This pull request is ready to be reviewed
