### PR TITLE
Add lower bounds to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,21 +39,21 @@ requires-python = ">=3.9,<3.13"
 dependencies = [
     "deprecated",
     "humanize",
-    "nibabel",
+    "nibabel>=2",
     "numpy>=1.15",
-    "scipy",
+    "scipy>=0.10",
     "simpleitk!=2.0.*,!=2.1.1.1",
-    "torch>=1.1",
+    "torch>=1.13",
     "tqdm",
     "typer",
 ]
 
 [project.optional-dependencies]
 csv = [
-    "pandas",
+    "pandas>=1",
 ]
 plot = [
-    "matplotlib",
+    "matplotlib>=2",
 ]
 
 [project.scripts]
@@ -73,33 +73,34 @@ dev = [
     { include-group = "doc" },
     { include-group = "maintain" },
     { include-group = "test" },
-    "ipykernel",
-    "ruff",
+    "ipykernel>=6.29.5",
+    "ruff>=0.8.1",
+    "ipywidgets>=8.1.5",
 ]
 doc = [
-    "einops",
-    "furo",
-    "matplotlib",
-    "sphinx",
-    "sphinx-autobuild",
-    "sphinx-copybutton",
-    "sphinx-gallery",
-    "sphinxext-opengraph",
+    "einops>=0.8.0",
+    "furo>=2024.8.6",
+    "matplotlib>=3.9.3",
+    "sphinx>=7.4.7",
+    "sphinx-autobuild>=2024.10.3",
+    "sphinx-copybutton>=0.5.2",
+    "sphinx-gallery>=0.18.0",
+    "sphinxext-opengraph>=0.9.1",
 ]
 maintain = [
-    "bump2version",
-    "pre-commit-uv",
+    "bump2version>=1.0.1",
+    "pre-commit-uv>=4.1.4",
 ]
 test = [
-    "coverage",
-    "mypy",
-    "parameterized",
+    "coverage>=7.6.8",
+    "mypy>=1.13.0",
+    "parameterized>=0.9.0",
     "pillow",
-    "pytest",
-    "pytest-cov",
-    "pytest-sugar",
-    "tox-uv",
-    "types-deprecated",
+    "pytest>=8.3.4",
+    "pytest-cov>=6.0.0",
+    "pytest-sugar>=1.0.0",
+    "tox-uv>=1.16.0",
+    "types-deprecated>=1.2.15.20241117",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,15 +37,16 @@ classifiers = [
 keywords = ["medical", "image processing", "pytorch", "augmentation", "mri"]
 requires-python = ">=3.9,<3.13"
 dependencies = [
-    "deprecated",
-    "humanize",
-    "nibabel>=2",
-    "numpy>=1.15",
-    "scipy>=0.10",
-    "simpleitk!=2.0.*,!=2.1.1.1",
-    "torch>=1.13",
-    "tqdm",
-    "typer",
+    "deprecated>=1.2",
+    "humanize>=0.1",
+    "nibabel>=3",
+    "numpy>=1.20",
+    "rich>=3",
+    "scipy>=1.7",
+    "simpleitk >=1.3, !=2.0.*, !=2.1.1.1",
+    "torch>=1.9",
+    "tqdm>=4.40",
+    "typer>=0.1",
 ]
 
 [project.optional-dependencies]
@@ -53,7 +54,7 @@ csv = [
     "pandas>=1",
 ]
 plot = [
-    "matplotlib>=2",
+    "matplotlib>=3.4",
 ]
 
 [project.scripts]
@@ -80,7 +81,7 @@ dev = [
 doc = [
     "einops>=0.8.0",
     "furo>=2024.8.6",
-    "matplotlib>=3.9.3",
+    "matplotlib>=3.4",
     "sphinx>=7.4.7",
     "sphinx-autobuild>=2024.10.3",
     "sphinx-copybutton>=0.5.2",
@@ -95,7 +96,7 @@ test = [
     "coverage>=7.6.8",
     "mypy>=1.13.0",
     "parameterized>=0.9.0",
-    "pillow",
+    "pillow>=8",
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
     "pytest-sugar>=1.0.0",

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -159,6 +159,7 @@ def test_write_nd_with_a_read_it_with_b(save_lib, load_lib, dims):
         tensor.squeeze(),
         loaded_tensor.squeeze(),
         msg=f'Save lib: {save_lib}; load lib: {load_lib}; dims: {dims}',
+        check_stride=False,
     )
     TorchioTestCase.assert_tensor_equal(affine, loaded_affine)
 

--- a/tests/transforms/preprocessing/test_histogram_standardization.py
+++ b/tests/transforms/preprocessing/test_histogram_standardization.py
@@ -1,3 +1,5 @@
+from packaging.version import Version
+
 import numpy as np
 import pytest
 import torch
@@ -80,7 +82,10 @@ class TestHistogramStandardization(TorchioTestCase):
         landmarks_dict = {'image': landmarks}
         landmarks_path = self.dir / 'landmarks_dict.pth'
         torch.save(landmarks_dict, landmarks_path)
-        landmarks_dict = torch.load(landmarks_path, weights_only=False)
+        kwargs = {}
+        if Version(torch.__version__) >= Version('1.13'):
+            kwargs["weights_only"] = False
+        landmarks_dict = torch.load(landmarks_path, **kwargs)
         transform = HistogramStandardization(landmarks_dict)
         transform(self.dataset[0])
 

--- a/tests/transforms/preprocessing/test_to_canonical.py
+++ b/tests/transforms/preprocessing/test_to_canonical.py
@@ -28,6 +28,7 @@ class TestToCanonical(TorchioTestCase):
         self.assert_tensor_almost_equal(
             transformed.t1.data,
             torch.from_numpy(array_flip),
+            check_stride=False,
         )
 
         fixture = np.eye(4)


### PR DESCRIPTION
This pull request includes several updates to dependencies in the `pyproject.toml` file and some adjustments in the test files to ensure compatibility with the latest versions of libraries. The most important changes include updating the dependency versions, adding a new dependency, and modifying test functions to handle version-specific parameters.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L40-R57): Updated the versions of several dependencies to ensure compatibility and improve stability. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L40-R57) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L76-R104)

Test adjustments:

* [`tests/data/test_io.py`](diffhunk://#diff-74d11ac28a1e270c788b7ebeca4d4ab4e47edaf464748bf3e991ce1c96bd7e76R162): Added `check_stride=False` to the assert statement in the `test_write_nd_with_a_read_it_with_b` function to handle new library behaviors.
* [`tests/transforms/preprocessing/test_histogram_standardization.py`](diffhunk://#diff-ba3b03625c21c90870f1ca4004a729e167ab4e6698df4651e2b4e160f92c6fbeL83-R88): Added conditional logic to handle the `weights_only` parameter based on the version of `torch`.
* [`tests/transforms/preprocessing/test_to_canonical.py`](diffhunk://#diff-f94ae254ad5a1646dac2e4468b02335817dbe29e7dfeb108fc83ca993981a9a9R31): Added `check_stride=False` to the assert statement in the `test_las_to_ras` function to manage new library behaviors.
* [`tests/transforms/preprocessing/test_histogram_standardization.py`](diffhunk://#diff-ba3b03625c21c90870f1ca4004a729e167ab4e6698df4651e2b4e160f92c6fbeR1-R2): Added import for `Version` from `packaging.version` to handle version-specific logic.