### PR TITLE
Add bump-my-version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,0 @@
-[bumpversion]
-current_version = 0.20.2
-commit = True
-tag = True
-
-[bumpversion:file:src/torchio/__init__.py]
-
-[bumpversion:file:pyproject.toml]

--- a/justfile
+++ b/justfile
@@ -18,3 +18,9 @@ clean:
 setup: install_uv
     uv sync --all-extras --all-groups
     uv run pre-commit install
+
+bump part="patch":
+    uv run bump-my-version bump {{part}}
+
+bump-dry:
+    uv run bump-my-version bump --dry-run

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ setup: install_uv
     uv run pre-commit install
 
 bump part="patch":
-    uv run bump-my-version bump {{part}}
+    uv run bump-my-version bump {{part}} --verbose
 
-bump-dry:
-    uv run bump-my-version bump --dry-run
+bump-dry part='patch':
+    uv run bump-my-version bump {{part}} --dry-run --verbose --allow-dirty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,21 @@ test = [
     "types-deprecated",
 ]
 
+[tool.bumpversion]
+current_version = "0.20.2"
+commit = true
+tag = true
+
+[[tool.bumpversion.files]]
+filename = "src/torchio/__init__.py"
+search = "__version__ = '{current_version}'"
+replace = "__version__ = '{new_version}'"
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
 [tool.mypy]
 pretty = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ doc = [
     "sphinxext-opengraph",
 ]
 maintain = [
-    "bump2version",
+    "bump-my-version",
     "pre-commit-uv",
 ]
 test = [


### PR DESCRIPTION
This pull request includes several changes to the version bumping configuration and related files. The most important changes involve replacing `bump2version` with `bump-my-version` and updating the configuration accordingly.

Changes to version bumping configuration:

* [`.bumpversion.cfg`](diffhunk://#diff-9ea6e1e3dde6d4a7e08c7c88eceed69ca745d0d2c779f8f85219b22266efff7fL1-L8): Removed the old `bumpversion` configuration file.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L90-R90): Replaced `bump2version` with `bump-my-version` in the `maintain` section and added the new `bumpversion` configuration under `[tool.bumpversion]`.

New bump commands:

* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R21-R26): Added new commands `bump` and `bump-dry` for version bumping using `bump-my-version`.