### PR TITLE
Try publishing with uv

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,11 +39,15 @@ jobs:
           name: dist
           path: dist
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
       - name: Publish package to TestPyPI
-        run: uv publish --publish-url https://test.pypi.org/legacy/
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+      - name: Install uv
+        if: startsWith(github.ref, 'refs/tags')
+        uses: astral-sh/setup-uv@v4
 
       - name: Publish package to PyPI if commit is tagged
         # Publish only tagged commits

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
 
-      - name: Install uv
+      - name: Install uv if commit is tagged
         if: startsWith(github.ref, 'refs/tags')
         uses: astral-sh/setup-uv@v4
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,9 +46,10 @@ jobs:
         run: |
           uv publish \
             --check-url https://test.pypi.org/simple \
-            --publish-url https://test.pypi.org/legacy
+            --publish-url https://test.pypi.org/legacy \
+            --verbose
 
       - name: Publish package to PyPI if commit is tagged
         # Publish only tagged commits
         if: startsWith(github.ref, 'refs/tags')
-        run: uv publish
+        run: uv publish --verbose

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,19 +30,22 @@ jobs:
       id-token: write
 
     steps:
+      - name: Print ref
+        run: echo ${{ github.ref }}
+
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
 
-      - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
 
-      - name: Publish TorchIO to PyPI if commit is tagged
+      - name: Publish package to TestPyPI
+        run: uv publish --publish-url https://test.pypi.org/legacy/
+
+      - name: Publish package to PyPI if commit is tagged
         # Publish only tagged commits
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: uv publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,15 +39,15 @@ jobs:
           name: dist
           path: dist
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
       - name: Publish package to TestPyPI
-        run: |
-          uv publish \
-            --check-url https://test.pypi.org/simple \
-            --publish-url https://test.pypi.org/legacy \
-            --verbose
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+      - name: Install uv
+        if: startsWith(github.ref, 'refs/tags')
+        uses: astral-sh/setup-uv@v4
 
       - name: Publish package to PyPI if commit is tagged
         # Publish only tagged commits

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,15 +39,14 @@ jobs:
           name: dist
           path: dist
 
-      - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-
       - name: Install uv
-        if: startsWith(github.ref, 'refs/tags')
         uses: astral-sh/setup-uv@v4
+
+      - name: Publish package to TestPyPI
+        run: |
+          uv publish \
+            --check-url https://test.pypi.org/simple \
+            --publish-url https://test.pypi.org/legacy
 
       - name: Publish package to PyPI if commit is tagged
         # Publish only tagged commits


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/publish.yml` file to enhance the workflow for publishing packages. The changes include adding a step to print the reference, installing `uv` before publishing, and modifying the publish command.

Enhancements to the publishing workflow:

* Added a step to print the GitHub reference for debugging purposes. (`.github/workflows/publish.yml`, [.github/workflows/publish.ymlR33-R35](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R33-R35))
* Updated the workflow to install `uv` if the commit is tagged, ensuring the necessary environment is set up before publishing. (`.github/workflows/publish.yml`, [.github/workflows/publish.ymlL45-R55](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L45-R55))
* Changed the publish command to use `uv publish --verbose` for more detailed output during the publishing process. (`.github/workflows/publish.yml`, [.github/workflows/publish.ymlL45-R55](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L45-R55))