### PR TITLE
Add antialiasing option for downsampling

### DIFF
--- a/src/torchio/transforms/preprocessing/spatial/resample.py
+++ b/src/torchio/transforms/preprocessing/spatial/resample.py
@@ -52,13 +52,15 @@ class Resample(SpatialTransform):
         label_interpolation: See :ref:`Interpolation`.
         scalars_only: Apply only to instances of :class:`~torchio.ScalarImage`.
             Used internally by :class:`~torchio.transforms.RandomAnisotropy`.
-        antialias: If ``True``, apply a Gaussian smoothing before
-            downsampling, along any dimension that will be downsampled.
-            This is useful to avoid aliasing artifacts when downsampling
-            images. The standard deviation of the Gaussian kernel
-            is computed according to the method described in Cardoso et al.,
-            `Scale factor point spread function matching: beyond aliasing in
-            image resampling
+        antialias: If ``True``, apply Gaussian smoothing before
+            downsampling along any dimension that will be downsampled. For example,
+            if the input image has spacing (0.5, 0.5, 4) and the target
+            spacing is (1, 1, 1), the image will be smoothed along the first two
+            dimensions before resampling. Label maps are not smoothed.
+            The standard deviations of the Gaussian kernels are computed according to
+            the method described in Cardoso et al.,
+            `Scale factor point spread function matching: beyond aliasing in image
+            resampling
             <https://link.springer.com/chapter/10.1007/978-3-319-24571-3_81>`_,
             MICCAI 2015.
         **kwargs: See :class:`~torchio.transforms.Transform` for additional
@@ -67,8 +69,8 @@ class Resample(SpatialTransform):
     Example:
         >>> import torch
         >>> import torchio as tio
-        >>> transform = tio.Resample(1)                     # resample all images to 1mm iso
-        >>> transform = tio.Resample((2, 2, 2))             # resample all images to 2mm iso
+        >>> transform = tio.Resample()                      # resample all images to 1mm isotropic
+        >>> transform = tio.Resample(2)                     # resample all images to 2mm isotropic
         >>> transform = tio.Resample('t1')                  # resample all images to 't1' image space
         >>> # Example: using a precomputed transform to MNI space
         >>> ref_path = tio.datasets.Colin27().t1.path  # this image is in the MNI space, so we can use it as reference/target
@@ -76,6 +78,11 @@ class Resample(SpatialTransform):
         >>> image = tio.ScalarImage(tensor=torch.rand(1, 256, 256, 180), to_mni=affine_matrix)  # 'to_mni' is an arbitrary name
         >>> transform = tio.Resample(colin.t1.path, pre_affine_name='to_mni')  # nearest neighbor interpolation is used for label maps
         >>> transformed = transform(image)  # "image" is now in the MNI space
+
+    .. note::
+        The ``antialias`` option is recommended when large (e.g. > 2×) downsampling
+        factors are expected, particularly for offline (before training) preprocessing,
+        when run times are not a concern.
 
     .. plot::
 


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->

Related to #48.

**Description**

<!-- Write a few sentences describing the changes proposed in this pull request. -->

```python
import torchio as tio

image = tio.datasets.Colin27().t1
image.plot()

factor = 8
downsampled_old = tio.Resample(factor, antialias=False)(image)
downsampled_old.plot()
downsampled_new = tio.Resample(factor, antialias=True)(image)
downsampled_new.plot()
```

![image](https://github.com/user-attachments/assets/a5504f00-ca71-4841-832d-3249f5999b51)
![image](https://github.com/user-attachments/assets/19ab1794-c760-42ae-9b6f-b66c7371974a)
![image](https://github.com/user-attachments/assets/b7004b76-82d9-4fc6-aa3e-955b51bd10ae)

Note e.g. the ventricles and basal ganglia in the sagittal view.

One more example with a test image. Note aliasing is smaller when enabling the new setting.

![image](https://github.com/user-attachments/assets/42d2452a-da86-4f1f-902b-1b061b5cbf9e)
![image](https://github.com/user-attachments/assets/d3a4d311-ccf1-4d87-9195-aad41a4ac699)
![image](https://github.com/user-attachments/assets/c6204f66-a27f-4e01-befd-16c9d6ec4fb6)


**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup ready
- Changes are
  - [x] Non-breaking (would not break existing functionality)
  - [ ] Breaking (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] In-line docstrings updated
- [ ] Documentation updated
- [ ] This pull request is ready to be reviewed
